### PR TITLE
Fixed f-string for search query

### DIFF
--- a/NGPIris/cli/functions.py
+++ b/NGPIris/cli/functions.py
@@ -44,7 +44,7 @@ def search(ctx, query, file):
         #Search for each item in query file
         qdict = {}
         for line in lines:
-            log.info('[-- query: {line} --]')
+            log.info(f"[-- query: {line} --]")
             found_objs = ctx['hcpm'].search_objects(line)
             if len(found_objs) > 0:
                 for obj in found_objs:


### PR DESCRIPTION
Got the following log:

```
[2021-10-07 15:05:14,917] - INFO: [-- query: {line} --]
[2021-10-07 15:05:14,939] - INFO: Nothing found
```

Fixed a missing f-string for the log o {line} works properly