### PR TITLE
Autotest exception fix

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -115,7 +115,7 @@ def bucketcheck(fn):
 
 class HCPManager:
     def __init__(self, endpoint="", aws_access_key_id="", aws_secret_access_key="", \
-                 bucket=None, credentials_path="", autotest=True, debug=False):
+                 bucket=None, credentials_path="", debug=False):
         self.bucketname = bucket
         self.bucket = None
         
@@ -152,9 +152,6 @@ class HCPManager:
 
         if self.bucketname:
             self.attach_bucket(bucket)
-
-        if autotest:
-            self.test_connection()
 
     def list_buckets(self):
         """List all available buckets at endpoint."""

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -162,9 +162,9 @@ class HCPManager:
 
     def test_connection(self):
         """Validate the connection works with as little overhead as possible."""
+        if self.bucketname is None:
+            raise UnattachedBucketError("No bucket assigned for connection test")
         try:
-            if self.bucketname is None:
-                raise ConnectionError("No bucket assigned")
             self.s3.meta.client.head_bucket(Bucket=self.bucketname)
         except ConnectionError:
             log.error("Invalid access, credentials or bucket")


### PR DESCRIPTION
## Contents
Remove autotest kwarg from HCPManager and fix exception raise within test_connection.

### The What

### The Why
It's better to give users the option to test the connection manually than to force it by default.

### The How
Move check for supplied bucket name outside try:except and substitute error for UnattachedBucketError.
Remove autotest kwarg and references to it.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
* `git clone git@github.com:genomic-medicine-sweden/NGPIris.git`
* `cd NGPIris && git checkout <BRANCH>`
* `bash setup.sh`
* `source activate hpcenv`

### Tests
* `pytest tests/`
* Potential additional tests

### Expected outcome:
* Pytest resolves without crashes
* Potential additional results

## Confirmations:
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
