### PR TITLE
Root cli testconnection

### DIFF
--- a/NGPIris/cli/base.py
+++ b/NGPIris/cli/base.py
@@ -32,6 +32,7 @@ def root(ctx, endpoint, access_key_id, access_key, bucket, credentials,logfile):
     ctx.obj = {}
     hcpm = HCPManager(ep, aid, key, bucket=bucket)
     hcpm.attach_bucket(bucket)
+    hcpm.test_connection()
     ctx.obj["hcpm"] = hcpm
 
     if logfile != "":

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -163,8 +163,8 @@ class HCPManager:
             raise UnattachedBucketError("No bucket assigned for connection test")
         try:
             self.s3.meta.client.head_bucket(Bucket=self.bucketname)
-        except ConnectionError:
-            log.error("Invalid access, credentials or bucket")
+        except Exception:
+            raise ConnectionError("Invalid access, credentials or bucket specified.")
 
     def set_bucket(self, bucket):
         self.bucketname = bucket


### PR DESCRIPTION
## Contents
A fix to erroneous exception catch when testing the connection and addition of test connection to the root cli command.

### The What


### The Why
Testing the connection with every cli command helps users debug potential fails (likely credential issues) that would otherwise cause non-descriptive exceptions downstream.

### The How
Add a call to the test_connection function to the root cli command from which every other command inherits.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
* `git clone git@github.com:genomic-medicine-sweden/NGPIris.git`
* `cd NGPIris && git checkout <BRANCH>`
* `bash setup.sh`
* `source activate hpcenv`

### Tests
* `pytest tests/`
* Potential additional tests

### Expected outcome:
* Pytest resolves without crashes
* Potential additional results

## Confirmations:
- [x] Code reviewed by @sylvinite 
- [x] Code tested by @sylvinite 
