### PR TITLE
Urllib3 version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ NGP Iris is designed with two use cases in mind:
 ## Getting started
 
 ### Easy installation
+:warning: **Currently unable to deploy fixes to pypi!**
+`git clone` and `pip install .` locally to get latest version.
 ```
 pip install NGPIris
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,6 +39,6 @@ tomli>=1.2.1
 tqdm>=4.62.3
 twine>=3.4.2
 typing-extensions>=3.10.0.2
-urllib3>=1.25.11
+urllib3==1.26.18
 webencodings>=0.5.1
 zipp>=3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3>=1.12.34
 click>=7.1.2
 requests>=2.25.0
+urllib3==1.26.18


### PR DESCRIPTION
## Contents

### The What
A fix to the botocore.exceptions.SSLError thrown on urllib3 version 2.+

### The Why
Because no one likes things that do not work

### The How
Statically setting urllib3==1.26.18 in requirements
Python version 3.10+ has urllib3 version 2.+ by default.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
* `git clone git@github.com:genomic-medicine-sweden/NGPIris.git`
* `cd NGPIris && git checkout <BRANCH>`
* `bash setup.sh`
* `source activate hpcenv`

### Tests
* `pytest tests/`
* Potential additional tests

### Expected outcome:
* Pytest resolves without crashes
* Potential additional results

## Confirmations:
- [ ] Code reviewed by @octocat
- [ ] Code tested by @octocat
