### PR TITLE
Add `create_bucket`

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -189,6 +189,18 @@ class HCPHandler:
         self.test_connection(bucket_name = bucket_name)
         self.bucket_name = bucket_name
 
+    def create_bucket(self, bucket_name : str) -> None:
+        """
+        Create a bucket. The user in the given credentials will be the owner 
+        of the bucket
+
+        :param bucket_name: Name of the new bucket
+        :type bucket_name: str
+        """
+        self.s3_client.create_bucket(
+            Bucket = bucket_name
+        )
+
     def list_buckets(self) -> list[str]:
         """
         List all available buckets at endpoint.


### PR DESCRIPTION
Solution to #70. 

Side note: according to the HCP documentation, it is not possible to change the quotas of the bucket via S3 (https://docs.hitachivantara.com/r/en-us/content-platform/9.7.x/mk-95hcph001/using-the-hitachi-api-for-amazon-s3/bucket-and-object-properties/allocated-space)