### PR TITLE
Add GMC to HCP tenant mapping

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -85,7 +85,11 @@ class HCPHandler:
             if type(tenant_parse) is Result:
                 tenant = str(tenant_parse[0])
                 if endpoint_format_string == "https://{}.vgregion.sjunet.org": # Check if endpoint is Sjunet
-                    self.tenant = gmc_tenant_map[tenant]
+                    mapped_tenant = gmc_tenant_map.get(tenant)
+                    if mapped_tenant:
+                        self.tenant = mapped_tenant
+                    else:
+                        raise RuntimeError("The provided tenant name, \"" + tenant + "\", could is not a valid tenant name. Hint: did you spell it correctly?")
                 else:
                     self.tenant = tenant
                 
@@ -93,7 +97,7 @@ class HCPHandler:
         
 
         if not self.tenant:
-            raise RuntimeError("Unable to parse endpoint. Make sure that you have entered the correct endpoint in your credentials JSON file. Hint: The endpoint should *not* contain \"https://\" or port numbers")
+            raise RuntimeError("Unable to parse endpoint, \"" + self.endpoint + "\". Make sure that you have entered the correct endpoint in your credentials JSON file. Hints:\n - The endpoint should *not* contain \"https://\" or port numbers\n - Is the endpoint spelled correctly?")
         self.base_request_url = self.endpoint + ":9090/mapi/tenants/" + self.tenant
         self.aws_access_key_id = self.hcp["aws_access_key_id"]
         self.aws_secret_access_key = self.hcp["aws_secret_access_key"]

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -67,6 +67,7 @@ class HCPHandler:
         self.hcp = credentials_handler.hcp
         self.endpoint = "https://" + self.hcp["endpoint"]
 
+        # A lookup table for GMC names to HCP tenant names
         gmc_tenant_map = {
             "gmc-joint" : "vgtn0008",
             "gmc-west" : "vgtn0012",

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -67,13 +67,30 @@ class HCPHandler:
         self.hcp = credentials_handler.hcp
         self.endpoint = "https://" + self.hcp["endpoint"]
 
+        gmc_tenant_map = {
+            "gmc-joint" : "vgtn0008",
+            "gmc-west" : "vgtn0012",
+            "gmc-southeast" : "vgtn0014",
+            "gmc-south" : "vgtn0015",
+            "gmc-orebro" : "vgtn0016",
+            "gmc-karolinska" : "vgtn0017",
+            "gmc-north" : "vgtn0018",
+            "gmc-uppsala" : "vgtn0019"
+        }
+
         self.tenant = None
         for endpoint_format_string in ["https://{}.ngp-fs1000.vgregion.se", "https://{}.ngp-fs2000.vgregion.se", "https://{}.ngp-fs3000.vgregion.se", "https://{}.vgregion.sjunet.org"]:
             tenant_parse = parse(endpoint_format_string, self.endpoint) 
             if type(tenant_parse) is Result:
-                self.tenant = str(tenant_parse[0])
+                tenant = str(tenant_parse[0])
+                if endpoint_format_string == "https://{}.vgregion.sjunet.org": # Check if endpoint is Sjunet
+                    self.tenant = gmc_tenant_map[tenant]
+                else:
+                    self.tenant = tenant
+                
                 break
         
+
         if not self.tenant:
             raise RuntimeError("Unable to parse endpoint. Make sure that you have entered the correct endpoint in your credentials JSON file. Hint: The endpoint should *not* contain \"https://\" or port numbers")
         self.base_request_url = self.endpoint + ":9090/mapi/tenants/" + self.tenant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",
     "urllib3 == 1.26.19",
-    "boto3 >= 1.26.76",
+    "boto3 == 1.35.81",
     "parse >= 1.19.1",
     "RapidFuzz >= 3.10.1",
     "tqdm >= 4.66.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.0"
+version = "5.2.1.dev1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.1.dev1"
+version = "5.2.1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/tests/test_hcp.py
+++ b/tests/test_hcp.py
@@ -132,14 +132,23 @@ def test_download_folder(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
     custom_config.hcp_h.download_folder("a folder of data/", custom_config.result_path) 
 
-def test_search_objects_in_bucket(custom_config : CustomConfig) -> None:
+def test_search_in_bucket(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
     test_file = Path(custom_config.test_file_path).name 
-    custom_config.hcp_h.search_objects_in_bucket(test_file) 
+    custom_config.hcp_h.search_in_bucket(test_file) 
 
-def test_search_objects_in_bucket_without_mounting(custom_config : CustomConfig) -> None:
+def test_search_in_bucket_without_mounting(custom_config : CustomConfig) -> None:
     _hcp_h = custom_config.hcp_h 
-    _without_mounting(_hcp_h, HCPHandler.search_objects_in_bucket)
+    _without_mounting(_hcp_h, HCPHandler.search_in_bucket)
+
+def test_fuzzy_search_in_bucket(custom_config : CustomConfig) -> None:
+    test_mount_bucket(custom_config)
+    test_file = Path(custom_config.test_file_path).name 
+    custom_config.hcp_h.fuzzy_search_in_bucket(test_file) 
+
+def test_fuzzy_search_in_bucket_without_mounting(custom_config : CustomConfig) -> None:
+    _hcp_h = custom_config.hcp_h 
+    _without_mounting(_hcp_h, HCPHandler.fuzzy_search_in_bucket)
 
 def test_get_object_acl(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)


### PR DESCRIPTION
## Contents
### Summary
This pull request includes several updates to the `NGPIris` project, focusing on enhancing tenant name handling, updating dependencies, and expanding test coverage. The most important changes include adding a lookup table for tenant names, updating the project version and dependencies, and adding new test cases.

Enhancements to tenant name handling:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR70-R100): Added a lookup table for GMC names to HCP tenant names and modified the tenant parsing logic to use this table. This ensures that tenant names are correctly mapped and validated.

Project version and dependencies update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R8): Updated the project version from `5.2.0` to `5.2.1` and changed the `boto3` dependency to a specific version (`1.35.81`).

Expanded test coverage:

* [`tests/test_hcp.py`](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L135-R151): Renamed some test functions for clarity and added new test cases for fuzzy search functionality in the bucket.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
