### PR TITLE
Iris v.5.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,7 @@ queries/*.json
 !queries/query_template.json
 proxies/*.json
 !proxies/proxy_template.json
-tests/*.ini
+tests/*/*.ini
 !tests/test_conf_template.ini
 
 .DS_Store

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -80,7 +80,7 @@ class HCPHandler:
         }
 
         self.tenant = None
-        for endpoint_format_string in ["https://{}.ngp-fs1000.vgregion.se", "https://{}.ngp-fs2000.vgregion.se", "https://{}.ngp-fs3000.vgregion.se", "https://{}.vgregion.sjunet.org"]:
+        for endpoint_format_string in ["https://{}.ngp-fs1000.vgregion.se", "https://{}.ngp-fs2000.vgregion.se", "https://{}.ngp-fs3000.vgregion.se", "https://{}.hcp1.vgregion.se", "https://{}.vgregion.sjunet.org"]:
             tenant_parse = parse(endpoint_format_string, self.endpoint) 
             if type(tenant_parse) is Result:
                 tenant = str(tenant_parse[0])

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -284,6 +284,11 @@ class HCPHandler:
 
         pages_filtered = pages.search(filter_string)
         for object in pages_filtered:
+            # If there are no objects in the bucket, then `object` will be None,
+            # which means that we should break out of the for loop
+            if not object:
+                break
+
             # Split the object key by "/"
             split_object = object["Key"].split("/")
             # Check if the object is within the specified path_key depth

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -85,7 +85,11 @@ class HCPHandler:
             if type(tenant_parse) is Result:
                 tenant = str(tenant_parse[0])
                 if endpoint_format_string == "https://{}.vgregion.sjunet.org": # Check if endpoint is Sjunet
-                    self.tenant = gmc_tenant_map[tenant]
+                    mapped_tenant = gmc_tenant_map.get(tenant)
+                    if mapped_tenant:
+                        self.tenant = mapped_tenant
+                    else:
+                        raise RuntimeError("The provided tenant name, \"" + tenant + "\", could is not a valid tenant name. Hint: did you spell it correctly?")
                 else:
                     self.tenant = tenant
                 
@@ -93,7 +97,7 @@ class HCPHandler:
         
 
         if not self.tenant:
-            raise RuntimeError("Unable to parse endpoint. Make sure that you have entered the correct endpoint in your credentials JSON file. Hint: The endpoint should *not* contain \"https://\" or port numbers")
+            raise RuntimeError("Unable to parse endpoint, \"" + self.endpoint + "\". Make sure that you have entered the correct endpoint in your credentials JSON file. Hints:\n - The endpoint should *not* contain \"https://\" or port numbers\n - Is the endpoint spelled correctly?")
         self.base_request_url = self.endpoint + ":9090/mapi/tenants/" + self.tenant
         self.aws_access_key_id = self.hcp["aws_access_key_id"]
         self.aws_secret_access_key = self.hcp["aws_secret_access_key"]

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -67,6 +67,7 @@ class HCPHandler:
         self.hcp = credentials_handler.hcp
         self.endpoint = "https://" + self.hcp["endpoint"]
 
+        # A lookup table for GMC names to HCP tenant names
         gmc_tenant_map = {
             "gmc-joint" : "vgtn0008",
             "gmc-west" : "vgtn0012",

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -148,7 +148,7 @@ class HCPHandler:
         else:
             self.transfer_config = TransferConfig(
                 multipart_threshold = 10 * _MB,
-                max_concurrency = 60,
+                max_concurrency = 30,
                 multipart_chunksize = 40 * _MB,
                 use_threads = True
             )

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -67,13 +67,30 @@ class HCPHandler:
         self.hcp = credentials_handler.hcp
         self.endpoint = "https://" + self.hcp["endpoint"]
 
+        gmc_tenant_map = {
+            "gmc-joint" : "vgtn0008",
+            "gmc-west" : "vgtn0012",
+            "gmc-southeast" : "vgtn0014",
+            "gmc-south" : "vgtn0015",
+            "gmc-orebro" : "vgtn0016",
+            "gmc-karolinska" : "vgtn0017",
+            "gmc-north" : "vgtn0018",
+            "gmc-uppsala" : "vgtn0019"
+        }
+
         self.tenant = None
         for endpoint_format_string in ["https://{}.ngp-fs1000.vgregion.se", "https://{}.ngp-fs2000.vgregion.se", "https://{}.ngp-fs3000.vgregion.se", "https://{}.vgregion.sjunet.org"]:
             tenant_parse = parse(endpoint_format_string, self.endpoint) 
             if type(tenant_parse) is Result:
-                self.tenant = str(tenant_parse[0])
+                tenant = str(tenant_parse[0])
+                if endpoint_format_string == "https://{}.vgregion.sjunet.org": # Check if endpoint is Sjunet
+                    self.tenant = gmc_tenant_map[tenant]
+                else:
+                    self.tenant = tenant
+                
                 break
         
+
         if not self.tenant:
             raise RuntimeError("Unable to parse endpoint. Make sure that you have entered the correct endpoint in your credentials JSON file. Hint: The endpoint should *not* contain \"https://\" or port numbers")
         self.base_request_url = self.endpoint + ":9090/mapi/tenants/" + self.tenant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",
     "urllib3 == 1.26.19",
-    "boto3 >= 1.26.76",
+    "boto3 == 1.35.81",
     "parse >= 1.19.1",
     "RapidFuzz >= 3.10.1",
     "tqdm >= 4.66.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.0"
+version = "5.2.1.dev1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.1.dev1"
+version = "5.2.1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.2.dev5"
+version = "5.2.2"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.2.dev4"
+version = "5.2.2.dev5"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.1"
+version = "5.2.2.dev4"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/tests/test_hcp.py
+++ b/tests/test_hcp.py
@@ -132,14 +132,23 @@ def test_download_folder(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
     custom_config.hcp_h.download_folder("a folder of data/", custom_config.result_path) 
 
-def test_search_objects_in_bucket(custom_config : CustomConfig) -> None:
+def test_search_in_bucket(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
     test_file = Path(custom_config.test_file_path).name 
-    custom_config.hcp_h.search_objects_in_bucket(test_file) 
+    custom_config.hcp_h.search_in_bucket(test_file) 
 
-def test_search_objects_in_bucket_without_mounting(custom_config : CustomConfig) -> None:
+def test_search_in_bucket_without_mounting(custom_config : CustomConfig) -> None:
     _hcp_h = custom_config.hcp_h 
-    _without_mounting(_hcp_h, HCPHandler.search_objects_in_bucket)
+    _without_mounting(_hcp_h, HCPHandler.search_in_bucket)
+
+def test_fuzzy_search_in_bucket(custom_config : CustomConfig) -> None:
+    test_mount_bucket(custom_config)
+    test_file = Path(custom_config.test_file_path).name 
+    custom_config.hcp_h.fuzzy_search_in_bucket(test_file) 
+
+def test_fuzzy_search_in_bucket_without_mounting(custom_config : CustomConfig) -> None:
+    _hcp_h = custom_config.hcp_h 
+    _without_mounting(_hcp_h, HCPHandler.fuzzy_search_in_bucket)
 
 def test_get_object_acl(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)


### PR DESCRIPTION
## Contents

### Summary
This pull request includes several changes to the `NGPIris` project, focusing on improving tenant name handling, adjusting concurrency settings, and adding new test cases. The most important changes include adding a lookup table for tenant names, modifying the concurrency settings, and adding new test cases for fuzzy search functionality.

### Tenant name handling improvements:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR70-R100): Added a lookup table for GMC names to HCP tenant names and updated the logic to map tenant names correctly. Improved error messages for invalid tenant names and endpoint parsing.

### Concurrency settings adjustment:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL129-R151): Reduced the `max_concurrency` setting from 60 to 30 in the `TransferConfig` to optimize performance.

### Bug fixes:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR287-R291): Added a check to break out of the loop if there are no objects in the bucket during the `list_objects` method.

### Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R8): Updated the project version from `5.2.0` to `5.2.2` and changed the `boto3` dependency version to `1.35.81`.

### Test case additions:

* [`tests/test_hcp.py`](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L135-R151): Added new test cases for fuzzy search functionality in the bucket and renamed existing test methods for consistency.


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
