### PR TITLE
Add debug flag

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -3,6 +3,7 @@ import click
 from click.core import Context
 from json import dump
 from pathlib import Path
+from boto3 import set_stream_logger
 from botocore.paginate import PageIterator, Paginator
 from typing import Any, Generator
 from os import get_terminal_size
@@ -66,14 +67,22 @@ def add_trailing_slash(path : str) -> str:
 
 @click.group()
 @click.argument("credentials")
+@click.option(
+    "--debug",
+    help = "Get the debug log for running a command",
+    is_flag = True
+)
 @click.version_option(package_name = "NGPIris")
 @click.pass_context
-def cli(context : Context, credentials : str):
+def cli(context : Context, credentials : str, debug : bool):
     """
     NGP Intelligence and Repository Interface Software, IRIS. 
     
     CREDENTIALS refers to the path to the JSON credentials file.
     """
+    if debug:
+        set_stream_logger(name="")
+        
     context.ensure_object(dict)
     context.obj["hcph"] = HCPHandler(credentials)
 


### PR DESCRIPTION
## Contents

### Summary
This pull request includes changes to the `NGPIris/cli/__init__.py` file to add a new debugging option and improve logging capabilities. The most important changes are:

Logging and debugging enhancements:

* Added import for `set_stream_logger` from `boto3` to enable stream logging.
* Introduced a new `--debug` option in the `cli` function to enable debug logging when running commands. If the `--debug` flag is set, `set_stream_logger` is called to activate logging.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [ ] Code tested by @erik-brink 
