### PR TITLE
Add `dry-run` option

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -81,8 +81,14 @@ def cli(context : Context, credentials : str):
 @click.argument("bucket")
 @click.argument("source")
 @click.argument("destination")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
 @click.pass_context
-def upload(context : Context, bucket : str, source : str, destination : str):
+def upload(context : Context, bucket : str, source : str, destination : str, dry_run : bool):
     """
     Upload files to an HCP bucket/namespace. 
     
@@ -97,11 +103,17 @@ def upload(context : Context, bucket : str, source : str, destination : str):
     destination = add_trailing_slash(destination)
     if Path(source).is_dir():
         source = add_trailing_slash(source)
-        hcph.upload_folder(source, destination)
+        if dry_run:
+            click.echo("This command would have uploaded the folder \"" + source + "\" to \"" + destination + "\"")
+        else:
+            hcph.upload_folder(source, destination)
     else:
         file_name = Path(source).name
         destination += file_name
-        hcph.upload_file(source, destination)
+        if dry_run:
+            click.echo("This command would have uploaded the file \"" + source + "\" to \"" + destination + "\"")
+        else:
+            hcph.upload_file(source, destination)
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -171,8 +171,14 @@ def download(context : Context, bucket : str, source : str, destination : str, f
 @cli.command()
 @click.argument("bucket")
 @click.argument("object")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
 @click.pass_context
-def delete_object(context : Context, bucket : str, object : str):
+def delete_object(context : Context, bucket : str, object : str, dry_run : bool):
     """
     Delete an object from an HCP bucket/namespace. 
 
@@ -182,7 +188,12 @@ def delete_object(context : Context, bucket : str, object : str):
     """
     hcph : HCPHandler = get_HCPHandler(context)
     hcph.mount_bucket(bucket)
-    hcph.delete_object(object)
+    if not dry_run:
+        hcph.delete_object(object)
+    else: 
+        click.echo("This command would delete:")
+        click.echo(list(hcph.list_objects(object))[0])
+
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -187,8 +187,14 @@ def delete_object(context : Context, bucket : str, object : str):
 @cli.command()
 @click.argument("bucket")
 @click.argument("folder")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
 @click.pass_context
-def delete_folder(context : Context, bucket : str, folder : str):
+def delete_folder(context : Context, bucket : str, folder : str, dry_run : bool):
     """
     Delete a folder from an HCP bucket/namespace. 
 
@@ -198,7 +204,12 @@ def delete_folder(context : Context, bucket : str, folder : str):
     """
     hcph : HCPHandler = get_HCPHandler(context)
     hcph.mount_bucket(bucket)
-    hcph.delete_folder(folder)
+    if not dry_run:
+        hcph.delete_folder(folder)
+    else:
+        click.echo("By deleting \"" + folder + "\", the following objects would have been deleted (not including objects in sub-folders):")
+        for obj in hcph.list_objects(folder):
+            click.echo(obj)
 
 @cli.command()
 @click.pass_context


### PR DESCRIPTION
## Contents


### Summary
This pull request introduces a new `dry_run` option to several CLI commands in the `NGPIris` project. This option allows users to simulate the execution of commands without making actual changes, which is useful for testing and verification. The most important changes include adding the `dry_run` flag to the `upload`, `download`, `delete_object`, and `delete_folder` commands and modifying their behavior accordingly.

New `dry_run` option:

* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR84-R91): Added the `dry_run` option to the `upload` command to simulate uploading files or folders. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR84-R91) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR106-R115)
* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR134-R141): Added the `dry_run` option to the `download` command to simulate downloading files or folders. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR134-R141) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR156) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR189-R206)
* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR216-R233): Added the `dry_run` option to the `delete_object` command to simulate deleting an object.
* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR243-R248): Added the `dry_run` option to the `delete_folder` command to simulate deleting a folder.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
