### PR TITLE
Iris 5.3.0

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -81,8 +81,14 @@ def cli(context : Context, credentials : str):
 @click.argument("bucket")
 @click.argument("source")
 @click.argument("destination")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
 @click.pass_context
-def upload(context : Context, bucket : str, source : str, destination : str):
+def upload(context : Context, bucket : str, source : str, destination : str, dry_run : bool):
     """
     Upload files to an HCP bucket/namespace. 
     
@@ -97,11 +103,17 @@ def upload(context : Context, bucket : str, source : str, destination : str):
     destination = add_trailing_slash(destination)
     if Path(source).is_dir():
         source = add_trailing_slash(source)
-        hcph.upload_folder(source, destination)
+        if dry_run:
+            click.echo("This command would have uploaded the folder \"" + source + "\" to \"" + destination + "\"")
+        else:
+            hcph.upload_folder(source, destination)
     else:
         file_name = Path(source).name
         destination += file_name
-        hcph.upload_file(source, destination)
+        if dry_run:
+            click.echo("This command would have uploaded the file \"" + source + "\" to \"" + destination + "\"")
+        else:
+            hcph.upload_file(source, destination)
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -171,8 +171,14 @@ def download(context : Context, bucket : str, source : str, destination : str, f
 @cli.command()
 @click.argument("bucket")
 @click.argument("object")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
 @click.pass_context
-def delete_object(context : Context, bucket : str, object : str):
+def delete_object(context : Context, bucket : str, object : str, dry_run : bool):
     """
     Delete an object from an HCP bucket/namespace. 
 
@@ -182,7 +188,12 @@ def delete_object(context : Context, bucket : str, object : str):
     """
     hcph : HCPHandler = get_HCPHandler(context)
     hcph.mount_bucket(bucket)
-    hcph.delete_object(object)
+    if not dry_run:
+        hcph.delete_object(object)
+    else: 
+        click.echo("This command would delete:")
+        click.echo(list(hcph.list_objects(object))[0])
+
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -3,6 +3,7 @@ import click
 from click.core import Context
 from json import dump
 from pathlib import Path
+from boto3 import set_stream_logger
 from botocore.paginate import PageIterator, Paginator
 from typing import Any, Generator
 from os import get_terminal_size
@@ -66,14 +67,22 @@ def add_trailing_slash(path : str) -> str:
 
 @click.group()
 @click.argument("credentials")
+@click.option(
+    "--debug",
+    help = "Get the debug log for running a command",
+    is_flag = True
+)
 @click.version_option(package_name = "NGPIris")
 @click.pass_context
-def cli(context : Context, credentials : str):
+def cli(context : Context, credentials : str, debug : bool):
     """
     NGP Intelligence and Repository Interface Software, IRIS. 
     
     CREDENTIALS refers to the path to the JSON credentials file.
     """
+    if debug:
+        set_stream_logger(name="")
+        
     context.ensure_object(dict)
     context.obj["hcph"] = HCPHandler(credentials)
 

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -187,8 +187,14 @@ def delete_object(context : Context, bucket : str, object : str):
 @cli.command()
 @click.argument("bucket")
 @click.argument("folder")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
 @click.pass_context
-def delete_folder(context : Context, bucket : str, folder : str):
+def delete_folder(context : Context, bucket : str, folder : str, dry_run : bool):
     """
     Delete a folder from an HCP bucket/namespace. 
 
@@ -198,7 +204,12 @@ def delete_folder(context : Context, bucket : str, folder : str):
     """
     hcph : HCPHandler = get_HCPHandler(context)
     hcph.mount_bucket(bucket)
-    hcph.delete_folder(folder)
+    if not dry_run:
+        hcph.delete_folder(folder)
+    else:
+        click.echo("By deleting \"" + folder + "\", the following objects would have been deleted (not including objects in sub-folders):")
+        for obj in hcph.list_objects(folder):
+            click.echo(obj)
 
 @cli.command()
 @click.pass_context

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'NGPIris'
-copyright = '2024, Author'
+copyright = '2025, Author'
 author = 'Author'
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. NGPIris documentation master file, created by
-   sphinx-quickstart on Fri Sep 27 16:07:28 2024.
+   sphinx-quickstart on Fri Feb 14 09:54:45 2025.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.2"
+version = "5.2.3"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.3.dev2"
+version = "5.3.0"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.3.dev1"
+version = "5.2.3.dev2"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.2.3"
+version = "5.2.3.dev1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",


### PR DESCRIPTION
## Contents

### Summary
This pull request includes multiple changes to the `NGPIris` project, focusing on adding debug and dry-run options to the CLI commands, updating documentation, and incrementing the project version. The key changes are summarized below:

### CLI Enhancements:
* Added a `--debug` option to the `cli` command to enable debug logging for command execution.
* Introduced a `--dry_run` option to the `upload`, `download`, `delete_object`, and `delete_folder` commands to simulate command execution without making actual changes. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR70-R100) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR143-R150) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR225-R242) [[4]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR252-R257)

### Documentation Updates:
* Updated the project year in `docs/conf.py` to 2025.
* Adjusted the creation date in `docs/index.rst` to February 14, 2025.

### Version Increment:
* Updated the project version in `pyproject.toml` from `5.2.2` to `5.3.0`.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
