### PR TITLE
Add `show_progress_bar` parameter to relevant methods

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -349,6 +349,11 @@ class HCPHandler:
 
         :param local_file_path: Path to a file on your local system where the contents of the object file can be put
         :type local_file_path: str
+
+        :param show_progress_bar: Boolean choice of displaying a progress bar. Defaults to True
+        :type show_progress_bar: bool, optional
+
+        :raises ObjectDoesNotExist: If the object does not exist in the bucket
         """
         try:
             self.get_object(key)
@@ -391,7 +396,7 @@ class HCPHandler:
             use_download_limit : bool = False, 
             download_limit_in_bytes : Byte = TiB(1).to_Byte(), 
             show_progress_bar : bool = True
-        ) -> None:
+        ) -> None:  
         """
         Download multiple objects from a folder in the mounted bucket
 
@@ -407,7 +412,13 @@ class HCPHandler:
         :param download_limit_in_bytes: The optional download limit in Byte (from the package `bitmath`). Defaults to 1 TB (`TiB(1).to_Byte()`)
         :type download_limit_in_bytes: Byte, optional
 
+        :param show_progress_bar: Boolean choice of displaying a progress bar. Defaults to True
+        :type show_progress_bar: bool, optional
+        
+        :raises ObjectDoesNotExist: If the object does not exist in the bucket
+        
         :raises DownloadLimitReached: If download limit was reached while downloading files
+        
         :raises NotADirectory: If local_folder_path is not a directory
         """
         try:
@@ -438,6 +449,13 @@ class HCPHandler:
 
         :param key: An optional new name for the file object on the bucket. Defaults to the same name as the file
         :type key: str, optional
+
+        :param show_progress_bar: Boolean choice of displaying a progress bar. Defaults to True
+        :type show_progress_bar: bool, optional
+
+        :raises RuntimeError: If the \"\\\" is used in the file path 
+        
+        :raises ObjectAlreadyExist: If the object already exist on the mounted bucket
         """
         raise_path_error(local_file_path)
 
@@ -482,8 +500,12 @@ class HCPHandler:
 
         :param local_folder_path: Path to the folder to be uploaded
         :type local_folder_path: str
+
         :param key: An optional new name for the folder path on the bucket. Defaults to the same name as the local folder path
         :type key: str, optional
+
+        :param show_progress_bar: Boolean choice of displaying a progress bar. Defaults to True
+        :type show_progress_bar: bool, optional
         """
         raise_path_error(local_folder_path)
 

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -340,7 +340,7 @@ class HCPHandler:
             return False
 
     @check_mounted
-    def download_file(self, key : str, local_file_path : str) -> None:
+    def download_file(self, key : str, local_file_path : str, show_progress_bar : bool = True) -> None:
         """
         Download one object file from the mounted bucket
 
@@ -355,19 +355,27 @@ class HCPHandler:
         except:
             raise ObjectDoesNotExist("Could not find object", "\"" + key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\"")
         try:
-            file_size : int = self.s3_client.head_object(Bucket = self.bucket_name, Key = key)["ContentLength"]
-            with tqdm(
-                total = file_size, 
-                unit = "B", 
-                unit_scale = True, 
-                desc = key
-            ) as pbar:
+            if show_progress_bar:
+                file_size : int = self.s3_client.head_object(Bucket = self.bucket_name, Key = key)["ContentLength"]
+                with tqdm(
+                    total = file_size, 
+                    unit = "B", 
+                    unit_scale = True, 
+                    desc = key
+                ) as pbar:
+                    self.s3_client.download_file(
+                        Bucket = self.bucket_name, 
+                        Key = key, 
+                        Filename = local_file_path, 
+                        Config = self.transfer_config,
+                        Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
+                    )
+            else:
                 self.s3_client.download_file(
                     Bucket = self.bucket_name, 
                     Key = key, 
                     Filename = local_file_path, 
                     Config = self.transfer_config,
-                    Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
                 )
         except ClientError as e0: 
             print(str(e0))
@@ -376,7 +384,14 @@ class HCPHandler:
             raise Exception(e)
 
     @check_mounted
-    def download_folder(self, folder_key : str, local_folder_path : str, use_download_limit : bool = False, download_limit_in_bytes : Byte = TiB(1).to_Byte()) -> None:
+    def download_folder(
+            self, 
+            folder_key : str, 
+            local_folder_path : str, 
+            use_download_limit : bool = False, 
+            download_limit_in_bytes : Byte = TiB(1).to_Byte(), 
+            show_progress_bar : bool = True
+        ) -> None:
         """
         Download multiple objects from a folder in the mounted bucket
 
@@ -409,12 +424,12 @@ class HCPHandler:
                     current_download_size_in_bytes += Byte(object["Size"])
                     if current_download_size_in_bytes >= download_limit_in_bytes and use_download_limit:
                         raise DownloadLimitReached("The download limit was reached when downloading files")
-                    self.download_file(object["Key"], p.as_posix())
+                    self.download_file(object["Key"], p.as_posix(), show_progress_bar = show_progress_bar)
         else:
             raise NotADirectory(local_folder_path + " is not a directory")
 
     @check_mounted
-    def upload_file(self, local_file_path : str, key : str = "") -> None:
+    def upload_file(self, local_file_path : str, key : str = "", show_progress_bar : bool = True) -> None:
         """
         Upload one file to the mounted bucket
 
@@ -436,23 +451,32 @@ class HCPHandler:
         if self.object_exists(key):
             raise ObjectAlreadyExist("The object \"" + key + "\" already exist in the mounted bucket")
         else:
-            file_size : int = stat(local_file_path).st_size
-            with tqdm(
-                total = file_size, 
-                unit = "B", 
-                unit_scale = True, 
-                desc = local_file_path
-            ) as pbar:
+            if show_progress_bar:
+                file_size : int = stat(local_file_path).st_size
+                with tqdm(
+                    total = file_size, 
+                    unit = "B", 
+                    unit_scale = True, 
+                    desc = local_file_path
+                ) as pbar:
+                    self.s3_client.upload_file(
+                        Filename = local_file_path, 
+                        Bucket = self.bucket_name, 
+                        Key = key,
+                        Config = self.transfer_config,
+                        Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
+                    )
+            else:
                 self.s3_client.upload_file(
                     Filename = local_file_path, 
                     Bucket = self.bucket_name, 
                     Key = key,
                     Config = self.transfer_config,
-                    Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
                 )
 
+
     @check_mounted
-    def upload_folder(self, local_folder_path : str, key : str = "") -> None:
+    def upload_folder(self, local_folder_path : str, key : str = "", show_progress_bar : bool = True) -> None:
         """
         Upload the contents of a folder to the mounted bucket
 
@@ -468,7 +492,7 @@ class HCPHandler:
         filenames = listdir(local_folder_path)
 
         for filename in filenames:
-            self.upload_file(local_folder_path + filename, key + filename)
+            self.upload_file(local_folder_path + filename, key + filename, show_progress_bar = show_progress_bar)
 
     @check_mounted
     def delete_objects(self, keys : list[str], verbose : bool = True) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.3.0"
+version = "5.3.1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/tests/test_hcp.py
+++ b/tests/test_hcp.py
@@ -56,7 +56,19 @@ def test_list_objects_without_mounting(custom_config : CustomConfig) -> None:
 
 def test_upload_file(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
-    custom_config.hcp_h.upload_file(custom_config.test_file_path) 
+    
+    # With progress bar
+    custom_config.hcp_h.upload_file(
+        custom_config.test_file_path, 
+        custom_config.test_file_path
+    )
+    
+    # Without progress bar
+    custom_config.hcp_h.upload_file(
+        custom_config.test_file_path, 
+        custom_config.test_file_path + "_no_progress_bar", 
+        show_progress_bar = False
+    )
 
 def test_upload_file_without_mounting(custom_config : CustomConfig) -> None:
     _hcp_h = custom_config.hcp_h 
@@ -104,16 +116,29 @@ def test_get_folder_without_mounting(custom_config : CustomConfig) -> None:
 
 def test_get_file_in_sub_directory(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
-    test_file = Path(custom_config.test_file_path).name 
-    assert custom_config.hcp_h.object_exists(test_file) 
-    assert custom_config.hcp_h.get_object(test_file) 
+    assert custom_config.hcp_h.object_exists(custom_config.test_file_path) 
+    assert custom_config.hcp_h.get_object(custom_config.test_file_path) 
+
+from icecream import ic
 
 def test_download_file(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
-    Path(custom_config.result_path).mkdir() 
-    test_file = Path(custom_config.test_file_path).name 
-    custom_config.hcp_h.download_file(test_file, custom_config.result_path + test_file) 
-    assert cmp(custom_config.result_path + test_file, custom_config.test_file_path) 
+    Path(custom_config.result_path).mkdir()
+    
+    test_folder_path = str(custom_config.test_file_path).rsplit("/", maxsplit = 1)[0] + "/"
+    Path(custom_config.result_path + test_folder_path).mkdir(parents = True, exist_ok = True)
+
+    # With progress bar
+    custom_config.hcp_h.download_file(custom_config.test_file_path, custom_config.result_path + custom_config.test_file_path)
+    assert cmp(custom_config.result_path + custom_config.test_file_path, custom_config.test_file_path) 
+
+    # Without progress bar
+    custom_config.hcp_h.download_file(
+        custom_config.test_file_path + "_no_progress_bar", 
+        custom_config.result_path + custom_config.test_file_path + "_no_progress_bar",
+        show_progress_bar = False
+    )
+    assert cmp(custom_config.result_path + custom_config.test_file_path, custom_config.test_file_path) 
 
 def test_download_file_without_mounting(custom_config : CustomConfig) -> None:
     _hcp_h = custom_config.hcp_h 
@@ -152,8 +177,7 @@ def test_fuzzy_search_in_bucket_without_mounting(custom_config : CustomConfig) -
 
 def test_get_object_acl(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
-    test_file = Path(custom_config.test_file_path).name 
-    custom_config.hcp_h.get_object_acl(test_file) 
+    custom_config.hcp_h.get_object_acl(custom_config.test_file_path) 
 
 def test_get_object_acl_without_mounting(custom_config : CustomConfig) -> None:
     _hcp_h = custom_config.hcp_h 
@@ -189,8 +213,8 @@ def test_get_bucket_acl_without_mounting(custom_config : CustomConfig) -> None:
 
 def test_delete_file(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
-    test_file = Path(custom_config.test_file_path).name 
-    custom_config.hcp_h.delete_object(test_file) 
+    custom_config.hcp_h.delete_object(custom_config.test_file_path) 
+    custom_config.hcp_h.delete_object(custom_config.test_file_path + "_no_progress_bar")
     custom_config.hcp_h.delete_object("a_sub_directory/a_file") 
     custom_config.hcp_h.delete_object("a_sub_directory") 
 


### PR DESCRIPTION
## Contents

### Summary
This pull request introduces several enhancements to the `NGPIris` project, focusing on adding progress bar functionality for file and folder operations, updating tests to accommodate these changes, and incrementing the project version. The most important changes include adding an optional `show_progress_bar` parameter to key methods and updating the tests accordingly.

Enhancements to file and folder operations:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL343-R343): Added an optional `show_progress_bar` parameter to the `download_file`, `download_folder`, `upload_file`, and `upload_folder` methods to allow users to display a progress bar during these operations. [[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL343-R343) [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR352-R363) [[3]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR378-R399) [[4]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR415-R421) [[5]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL412-R443) [[6]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR452-R458) [[7]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR472) [[8]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR487-R508) [[9]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL471-R517)

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented the project version from `5.3.0` to `5.3.1`.

Updates to tests:

* [`tests/test_hcp.py`](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L59-R71): Updated tests to include scenarios with and without the progress bar for file upload and download operations. [[1]](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L59-R71) [[2]](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L107-R141) [[3]](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L155-R180) [[4]](diffhunk://#diff-fc0a36188b328a62f21f925f5c8dde3c29a5af1aead3d33feb372a4cee5ad060L192-R217)

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
