### PR TITLE
Fix `list_objects` 

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -263,13 +263,13 @@ class HCPHandler:
         List all objects in the mounted bucket as a generator. If one wishes to 
         get the result as a list, use :py:function:`list` to type cast the generator
 
-        :param path_key: Filter string for which keys to list, specifically for finding objects in certain folders.
+        :param path_key: Filter string for which keys to list, specifically for finding objects in certain folders. Defaults to \"the root\" of the bucket
         :type path_key: str, optional
         :param name_only: If True, yield only a the object names. If False, yield the full metadata about each object. Defaults to False.
         :type name_only: bool, optional
         :param files_only: If true, only yield file objects. Defaults to False
         :type files_only: bool, optional
-        :yield: A generator of all objects in a bucket
+        :yield: A generator of all objects in specified folder in a bucket
         :rtype: Generator
         """
         paginator : Paginator = self.s3_client.get_paginator("list_objects_v2")
@@ -313,19 +313,6 @@ class HCPHandler:
                             yield file_object["Key"]
                         else:
                             yield file_object
-
-            # Split the object key by "/"
-            #split_object = object["Key"].split("/")
-            ## Check if the object is within the specified path_key depth
-            #if len(split_object) <= split_path_key:
-            #    # Skip objects that are not at the desired depth
-            #    if (len(split_object) == split_path_key) and split_object[-1]:
-            #        continue
-            #    
-            #    if name_only:
-            #        yield str(object["Key"])
-            #    else:
-            #        yield object
         
                     
     @check_mounted

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -280,27 +280,30 @@ class HCPHandler:
             # Check if `page` is None
             if not page:
                 break
-            
-            for file_object in page.get("Contents", []):
-                file_object : dict
-                if file_object["Key"] != path_key:
-                    file_object["IsFile"] = True
-                    yield file_object
 
-            for folder_object in page.get("CommonPrefixes", []):
-                folder_object : dict
-                folder_object_metadata = self.get_object(folder_object["Prefix"])
-                
-                yield {
-                    "Key" : folder_object["Prefix"],
-                    "LastModified" : folder_object_metadata["LastModified"],
-                    "ETag" : folder_object_metadata["ETag"],
-                    "IsFile" : False,
-                }
-                #ic(folder_object)
+            if files_only:
+                for file_object in page.get("Contents", []):
+                    file_object : dict
+                    if file_object["Key"] != path_key:
+                        file_object["IsFile"] = True
+                        yield file_object
+            else:
+                for folder_object in page.get("CommonPrefixes", []):
+                    folder_object : dict
+                    folder_object_metadata = self.get_object(folder_object["Prefix"])
+                    
+                    yield {
+                        "Key" : folder_object["Prefix"],
+                        "LastModified" : folder_object_metadata["LastModified"],
+                        "ETag" : folder_object_metadata["ETag"],
+                        "IsFile" : False,
+                    }
 
-            #ic(page_nb, page.get("Contents"), page.get("CommonPrefixes"))
-            #page_nb += 1
+                for file_object in page.get("Contents", []):
+                    file_object : dict
+                    if file_object["Key"] != path_key:
+                        file_object["IsFile"] = True
+                        yield file_object
 
             # Split the object key by "/"
             #split_object = object["Key"].split("/")

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -286,24 +286,33 @@ class HCPHandler:
                     file_object : dict
                     if file_object["Key"] != path_key:
                         file_object["IsFile"] = True
-                        yield file_object
+                        if name_only:
+                            yield file_object["Key"]
+                        else:
+                            yield file_object
             else:
                 for folder_object in page.get("CommonPrefixes", []):
                     folder_object : dict
                     folder_object_metadata = self.get_object(folder_object["Prefix"])
                     
-                    yield {
-                        "Key" : folder_object["Prefix"],
-                        "LastModified" : folder_object_metadata["LastModified"],
-                        "ETag" : folder_object_metadata["ETag"],
-                        "IsFile" : False,
-                    }
+                    if name_only: 
+                        yield folder_object["Prefix"]
+                    else:
+                        yield {
+                            "Key" : folder_object["Prefix"],
+                            "LastModified" : folder_object_metadata["LastModified"],
+                            "ETag" : folder_object_metadata["ETag"],
+                            "IsFile" : False,
+                        }
 
                 for file_object in page.get("Contents", []):
                     file_object : dict
                     if file_object["Key"] != path_key:
                         file_object["IsFile"] = True
-                        yield file_object
+                        if name_only:
+                            yield file_object["Key"]
+                        else:
+                            yield file_object
 
             # Split the object key by "/"
             #split_object = object["Key"].split("/")


### PR DESCRIPTION
## Contents

### Summary
This pull request includes changes to simplify and optimize the object listing functionality in the `NGPIris` project. The most important changes involve refactoring the `_list_objects_generator` function and modifying the `list_objects` method to improve performance and readability.

Refactoring and optimization:

* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL7-L11): Removed unused imports and refactored the `_list_objects_generator` function to utilize the `list_objects` method from `HCPHandler` for improved performance and readability. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL7-L11) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL29-R27)

Enhancements to object listing:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL266-R316): Modified the `list_objects` method to include a `Delimiter` parameter in the paginator for better handling of folder structures. Improved the logic for filtering and yielding file and folder objects, including handling metadata and ensuring the correct depth of objects.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
