### PR TITLE
Add complete object list option

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -258,22 +258,33 @@ class HCPHandler:
         return list_of_buckets
 
     @check_mounted
-    def list_objects(self, path_key : str = "", name_only : bool = False, files_only : bool = False) -> Generator:
+    def list_objects(
+        self, 
+        path_key : str = "", 
+        list_all_bucket_objects : bool = False,
+        name_only : bool = False, 
+        files_only : bool = False
+    ) -> Generator:
         """
         List all objects in the mounted bucket as a generator. If one wishes to 
         get the result as a list, use :py:function:`list` to type cast the generator
 
         :param path_key: Filter string for which keys to list, specifically for finding objects in certain folders. Defaults to \"the root\" of the bucket
         :type path_key: str, optional
+        :param list_all_bucket_objects: If True, the value of `path_key` will be ignored and instead will list all objects in the bucket. Defaults to False
+        :type list_all_bucket_objects: bool, optional
         :param name_only: If True, yield only a the object names. If False, yield the full metadata about each object. Defaults to False.
         :type name_only: bool, optional
-        :param files_only: If true, only yield file objects. Defaults to False
+        :param files_only: If True, only yield file objects. Defaults to False
         :type files_only: bool, optional
         :yield: A generator of all objects in specified folder in a bucket
         :rtype: Generator
         """
         paginator : Paginator = self.s3_client.get_paginator("list_objects_v2")
-        pages : PageIterator = paginator.paginate(Bucket = self.bucket_name, Prefix = path_key, Delimiter = "/")
+        if list_all_bucket_objects:
+            pages : PageIterator = paginator.paginate(Bucket = self.bucket_name)
+        else:
+            pages : PageIterator = paginator.paginate(Bucket = self.bucket_name, Prefix = path_key, Delimiter = "/")
 
         for page in pages:
             page : dict | None
@@ -653,11 +664,11 @@ class HCPHandler:
             processor = utils.default_process 
 
         if not name_only:
-            full_list = list(self.list_objects())
+            full_list = list(self.list_objects(list_all_bucket_objects = True))
 
         for item, score, index in process.extract_iter(
                 search_string, 
-                self.list_objects(name_only = True), 
+                self.list_objects(list_all_bucket_objects = True, name_only = True), 
                 scorer = fuzz.partial_ratio,
                 processor = processor
             ):

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -597,7 +597,7 @@ class HCPHandler:
             key += "/"
 
         objects : list[str] = list(self.list_objects(key, name_only = True))
-        objects.append(key)
+        objects.append(key) # Include the object "folder" path to be deleted
 
         if not objects:
             raise RuntimeError("\"" + key + "\"" + " is not a valid path") #TODO: change this error

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -597,6 +597,7 @@ class HCPHandler:
             key += "/"
 
         objects : list[str] = list(self.list_objects(key, name_only = True))
+        objects.append(key)
 
         if not objects:
             raise RuntimeError("\"" + key + "\"" + " is not a valid path") #TODO: change this error


### PR DESCRIPTION
## Contents


### Summary
This pull request includes changes to the `NGPIris/hcp/hcp.py` file to add functionality for listing all objects in a bucket and to update the fuzzy search method accordingly. The most important changes include modifications to the `list_objects` method and the `fuzzy_search_in_bucket` method.

Enhancements to object listing:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL261-R286): Modified the `list_objects` method to include a new parameter `list_all_bucket_objects` which, when set to True, lists all objects in the bucket regardless of the `path_key`.

Updates to fuzzy search:

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL656-R671): Updated the `fuzzy_search_in_bucket` method to call `list_objects` with the `list_all_bucket_objects` parameter set to True to ensure all objects in the bucket are considered during the search.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
