### PR TITLE
Fix download folder method

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -426,7 +426,7 @@ def iris_generate_credentials_file(path : str, name : str):
             file_path = path + name
     
         if not Path(path).is_dir():
-            Path(path).mkdir()
+            Path(path).mkdir(parents=True)
     else:
         file_path = name
         

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -455,9 +455,13 @@ class HCPHandler:
                 p = Path(local_folder_path) / Path(object["Key"])
                 if not object["IsFile"]: # If the object is a "folder"
                     p.mkdir(parents=True)
-                    self.download_folder(folder_key=str(object['Key']), local_folder_path=str(local_folder_path), \
-                            use_download_limit=use_download_limit, show_progress_bar=show_progress_bar, \
-                            download_limit_in_bytes=download_limit_in_bytes - current_download_size_in_bytes)
+                    self.download_folder(
+                        folder_key = str(object['Key']), 
+                        local_folder_path = local_folder_path,
+                        use_download_limit = use_download_limit, 
+                        show_progress_bar = show_progress_bar,
+                        download_limit_in_bytes = download_limit_in_bytes - current_download_size_in_bytes
+                    )
                 else: # If the object is a file
                     current_download_size_in_bytes += Byte(object["Size"])
                     if current_download_size_in_bytes >= download_limit_in_bytes and use_download_limit:

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -258,22 +258,33 @@ class HCPHandler:
         return list_of_buckets
 
     @check_mounted
-    def list_objects(self, path_key : str = "", name_only : bool = False, files_only : bool = False) -> Generator:
+    def list_objects(
+        self, 
+        path_key : str = "", 
+        list_all_bucket_objects : bool = False,
+        name_only : bool = False, 
+        files_only : bool = False
+    ) -> Generator:
         """
         List all objects in the mounted bucket as a generator. If one wishes to 
         get the result as a list, use :py:function:`list` to type cast the generator
 
         :param path_key: Filter string for which keys to list, specifically for finding objects in certain folders. Defaults to \"the root\" of the bucket
         :type path_key: str, optional
+        :param list_all_bucket_objects: If True, the value of `path_key` will be ignored and instead will list all objects in the bucket. Defaults to False
+        :type list_all_bucket_objects: bool, optional
         :param name_only: If True, yield only a the object names. If False, yield the full metadata about each object. Defaults to False.
         :type name_only: bool, optional
-        :param files_only: If true, only yield file objects. Defaults to False
+        :param files_only: If True, only yield file objects. Defaults to False
         :type files_only: bool, optional
         :yield: A generator of all objects in specified folder in a bucket
         :rtype: Generator
         """
         paginator : Paginator = self.s3_client.get_paginator("list_objects_v2")
-        pages : PageIterator = paginator.paginate(Bucket = self.bucket_name, Prefix = path_key, Delimiter = "/")
+        if list_all_bucket_objects:
+            pages : PageIterator = paginator.paginate(Bucket = self.bucket_name)
+        else:
+            pages : PageIterator = paginator.paginate(Bucket = self.bucket_name, Prefix = path_key, Delimiter = "/")
 
         for page in pages:
             page : dict | None
@@ -653,11 +664,11 @@ class HCPHandler:
             processor = utils.default_process 
 
         if not name_only:
-            full_list = list(self.list_objects())
+            full_list = list(self.list_objects(list_all_bucket_objects = True))
 
         for item, score, index in process.extract_iter(
                 search_string, 
-                self.list_objects(name_only = True), 
+                self.list_objects(list_all_bucket_objects = True, name_only = True), 
                 scorer = fuzz.partial_ratio,
                 processor = processor
             ):

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -25,8 +25,7 @@ from pathlib import Path
 
 from os import (
     stat,
-    listdir,
-    walk
+    listdir
 )
 from json import dumps
 from parse import (

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -597,7 +597,7 @@ class HCPHandler:
             key += "/"
 
         objects : list[str] = list(self.list_objects(key, name_only = True))
-        objects.append(key)
+        objects.append(key) # Include the object "folder" path to be deleted
 
         if not objects:
             raise RuntimeError("\"" + key + "\"" + " is not a valid path") #TODO: change this error

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -597,6 +597,7 @@ class HCPHandler:
             key += "/"
 
         objects : list[str] = list(self.list_objects(key, name_only = True))
+        objects.append(key)
 
         if not objects:
             raise RuntimeError("\"" + key + "\"" + " is not a valid path") #TODO: change this error

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -40,7 +40,6 @@ from rapidfuzz import (
 from requests import get
 from urllib3 import disable_warnings
 from tqdm import tqdm
-
 from bitmath import TiB, Byte
 
 from typing import Generator
@@ -450,11 +449,11 @@ class HCPHandler:
             raise ObjectDoesNotExist("Could not find object", "\"" + folder_key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\"")
         if Path(local_folder_path).is_dir():
             current_download_size_in_bytes = Byte(0) # For tracking download limit
-
-            for object in self.list_objects(folder_key): # Build the tree with directories or add files
+            (Path(local_folder_path) / Path(folder_key)).mkdir(parents = True) # Create "base folder"
+            for object in self.list_objects(folder_key): # Build the tree with directories or add files:
                 p = Path(local_folder_path) / Path(object["Key"])
                 if not object["IsFile"]: # If the object is a "folder"
-                    p.mkdir(parents=True)
+                    p.mkdir(parents = True)
                     self.download_folder(
                         folder_key = str(object["Key"]), 
                         local_folder_path = local_folder_path,

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -456,7 +456,7 @@ class HCPHandler:
                 if not object["IsFile"]: # If the object is a "folder"
                     p.mkdir(parents=True)
                     self.download_folder(
-                        folder_key = str(object['Key']), 
+                        folder_key = str(object["Key"]), 
                         local_folder_path = local_folder_path,
                         use_download_limit = use_download_limit, 
                         show_progress_bar = show_progress_bar,

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -1,4 +1,3 @@
-
 from NGPIris.parse_credentials import CredentialsHandler
 from NGPIris.hcp.helpers import (
     raise_path_error,
@@ -26,7 +25,8 @@ from pathlib import Path
 
 from os import (
     stat,
-    listdir
+    listdir,
+    walk
 )
 from json import dumps
 from parse import (
@@ -451,10 +451,14 @@ class HCPHandler:
             raise ObjectDoesNotExist("Could not find object", "\"" + folder_key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\"")
         if Path(local_folder_path).is_dir():
             current_download_size_in_bytes = Byte(0) # For tracking download limit
+
             for object in self.list_objects(folder_key): # Build the tree with directories or add files
                 p = Path(local_folder_path) / Path(object["Key"])
-                if object["Key"][-1] == "/": # If the object is a "folder"
+                if not object["IsFile"]: # If the object is a "folder"
                     p.mkdir(parents=True)
+                    self.download_folder(folder_key=str(object['Key']), local_folder_path=str(local_folder_path), \
+                            use_download_limit=use_download_limit, show_progress_bar=show_progress_bar, \
+                            download_limit_in_bytes=download_limit_in_bytes - current_download_size_in_bytes)
                 else: # If the object is a file
                     current_download_size_in_bytes += Byte(object["Size"])
                     if current_download_size_in_bytes >= download_limit_in_bytes and use_download_limit:

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -454,7 +454,7 @@ class HCPHandler:
             for object in self.list_objects(folder_key): # Build the tree with directories or add files
                 p = Path(local_folder_path) / Path(object["Key"])
                 if object["Key"][-1] == "/": # If the object is a "folder"
-                    p.mkdir()
+                    p.mkdir(parents=True)
                 else: # If the object is a file
                     current_download_size_in_bytes += Byte(object["Size"])
                     if current_download_size_in_bytes >= download_limit_in_bytes and use_download_limit:


### PR DESCRIPTION
## Contents

### Summary
This pull request includes several changes to the `NGPIris` project, primarily focusing on improving the functionality and robustness of the `hcp` module. Below are the most important changes:

### Improvements to Directory Handling:
* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL429-R429): Modified `iris_generate_credentials_file` to create parent directories if they do not exist (`mkdir(parents=True)`).
* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR453-R464): Updated `download_folder` to create parent directories when downloading folders and to recursively download nested folders.

### Enhancements to Object Listing:
* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL261-R285): Enhanced `list_objects` to include a new parameter `list_all_bucket_objects` for listing all objects in a bucket, ignoring the `path_key`.

### Bug Fixes and Improvements:
* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR607): Fixed `delete_folder` to include the folder path itself in the list of objects to be deleted.
* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL656-R679): Updated `fuzzy_search_in_bucket` to use the new `list_all_bucket_objects` parameter for more accurate searches.

### Code Cleanup:
* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL1): Removed an unnecessary blank line at the beginning of the file.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
