### PR TITLE
Dev fix simple upload

### DIFF
--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -489,6 +489,16 @@ class HCPHandler:
         :param show_progress_bar: Boolean choice of displaying a progress bar. Defaults to True
         :type show_progress_bar: bool, optional
 
+        :param upload_mode: 
+            The upload mode of the transfer is any of the following:
+                HCPHandler.UploadMode.STANDARD,
+                HCPHandler.UploadMode.SIMPLE,
+                HCPHandler.UploadMode.EQUAL_PARTS\n
+        :type upload_mode: UploadMode, optional
+
+        :param equal_parts: The number of equal parts that each file should be divided into when using the HCPHandler.UploadMode.EQUAL_PARTS mode. Default is 5
+        :type equal_parts: int, optional
+
         :raises RuntimeError: If the \"\\\" is used in the file path 
         
         :raises ObjectAlreadyExist: If the object already exist on the mounted bucket
@@ -538,7 +548,7 @@ class HCPHandler:
                 )
 
     @check_mounted
-    def upload_folder(self, local_folder_path : str, key : str = "", show_progress_bar : bool = True, use_simple_upload : bool = False) -> None:
+    def upload_folder(self, local_folder_path : str, key : str = "", show_progress_bar : bool = True, upload_mode : UploadMode = UploadMode.STANDARD, equal_parts : int = 5) -> None:
         """
         Upload the contents of a folder to the mounted bucket
 
@@ -550,6 +560,16 @@ class HCPHandler:
 
         :param show_progress_bar: Boolean choice of displaying a progress bar. Defaults to True
         :type show_progress_bar: bool, optional
+
+        :param upload_mode: 
+            The upload mode of the transfer is any of the following:
+                HCPHandler.UploadMode.STANDARD,
+                HCPHandler.UploadMode.SIMPLE,
+                HCPHandler.UploadMode.EQUAL_PARTS\n
+        :type upload_mode: UploadMode, optional
+
+        :param equal_parts: The number of equal parts that each file should be divided into when using the HCPHandler.UploadMode.EQUAL_PARTS mode. Default is 5
+        :type equal_parts: int, optional
         """
         raise_path_error(local_folder_path)
 
@@ -562,7 +582,8 @@ class HCPHandler:
                 local_folder_path + filename, 
                 key + filename, 
                 show_progress_bar = show_progress_bar, 
-                #use_simple_upload = use_simple_upload
+                upload_mode = upload_mode,
+                equal_parts = equal_parts
             )
 
     @check_mounted

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -42,6 +42,7 @@ from urllib3 import disable_warnings
 from tqdm import tqdm
 from bitmath import TiB, Byte
 
+from enum import Enum
 from typing import Generator
 
 _KB = 1024
@@ -468,9 +469,14 @@ class HCPHandler:
                     self.download_file(object["Key"], p.as_posix(), show_progress_bar = show_progress_bar)
         else:
             raise NotADirectory(local_folder_path + " is not a directory")
+    
+    class UploadMode(Enum):
+        STANDARD = "standard"
+        SIMPLE = "simple"
+        EQUAL_PARTS = "equal_parts"
 
     @check_mounted
-    def upload_file(self, local_file_path : str, key : str = "", show_progress_bar : bool = True, use_simple_upload : bool = False) -> None:
+    def upload_file(self, local_file_path : str, key : str = "", show_progress_bar : bool = True, upload_mode : UploadMode = UploadMode.STANDARD, equal_parts : int = 5) -> None:
         """
         Upload one file to the mounted bucket
 
@@ -499,44 +505,37 @@ class HCPHandler:
         if self.object_exists(key):
             raise ObjectAlreadyExist("The object \"" + key + "\" already exist in the mounted bucket")
         else:
+            file_size : int = stat(local_file_path).st_size
+
+            match upload_mode:
+                case HCPHandler.UploadMode.STANDARD:
+                    config = self.transfer_config
+                case HCPHandler.UploadMode.SIMPLE:
+                    config = TransferConfig(multipart_chunksize = file_size)
+                case HCPHandler.UploadMode.EQUAL_PARTS:
+                    config = TransferConfig(multipart_chunksize = round(file_size / equal_parts))
+
             if show_progress_bar:
-                file_size : int = stat(local_file_path).st_size
                 with tqdm(
                     total = file_size, 
                     unit = "B", 
                     unit_scale = True, 
                     desc = local_file_path
                 ) as pbar:
-                    if use_simple_upload:
-                        self.s3_client.upload_file(
-                            Filename = local_file_path, 
-                            Bucket = self.bucket_name, 
-                            Key = key,
-                            Config = TransferConfig(multipart_chunksize = round(file_size / 5)),
-                            Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
-                        )
-                    else:
-                        self.s3_client.upload_file(
-                            Filename = local_file_path, 
-                            Bucket = self.bucket_name, 
-                            Key = key,
-                            Config = self.transfer_config,
-                            Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
-                        )
+                    self.s3_client.upload_file(
+                        Filename = local_file_path, 
+                        Bucket = self.bucket_name, 
+                        Key = key,
+                        Config = config,
+                        Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
+                    )
             else:
-                if use_simple_upload:
-                    self.s3_client.upload_file(
-                        Filename = local_file_path, 
-                        Bucket = self.bucket_name, 
-                        Key = key,
-                    )
-                else:
-                    self.s3_client.upload_file(
-                        Filename = local_file_path, 
-                        Bucket = self.bucket_name, 
-                        Key = key,
-                        Config = self.transfer_config,
-                    )
+                self.s3_client.upload_file(
+                    Filename = local_file_path, 
+                    Bucket = self.bucket_name, 
+                    Key = key,
+                    Config = config,
+                )
 
     @check_mounted
     def upload_folder(self, local_folder_path : str, key : str = "", show_progress_bar : bool = True, use_simple_upload : bool = False) -> None:
@@ -563,7 +562,7 @@ class HCPHandler:
                 local_folder_path + filename, 
                 key + filename, 
                 show_progress_bar = show_progress_bar, 
-                use_simple_upload = use_simple_upload
+                #use_simple_upload = use_simple_upload
             )
 
     @check_mounted

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -512,7 +512,7 @@ class HCPHandler:
                             Filename = local_file_path, 
                             Bucket = self.bucket_name, 
                             Key = key,
-                            Config = TransferConfig(multipart_chunksize = file_size),
+                            Config = TransferConfig(multipart_chunksize = round(file_size / 5)),
                             Callback = lambda bytes_transferred : pbar.update(bytes_transferred)
                         )
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.4.2.dev5"
+version = "5.4.2.dev6"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/tests/test_hcp.py
+++ b/tests/test_hcp.py
@@ -1,12 +1,10 @@
 
-
 from pathlib import Path
 from filecmp import cmp
 from typing import Any, Callable
-
 from conftest import CustomConfig
-
 from NGPIris.hcp import HCPHandler
+from icecream import ic
 
 # --------------------------- Helper fucntions ---------------------------------
 
@@ -70,6 +68,15 @@ def test_upload_file(custom_config : CustomConfig) -> None:
         show_progress_bar = False
     )
 
+    # Test every upload mode
+    for mode in HCPHandler.UploadMode:
+        ic(mode, custom_config.test_file_path + "_" + str(mode).replace(".", "_"))
+        custom_config.hcp_h.upload_file(
+            custom_config.test_file_path, 
+            custom_config.test_file_path + "_" + str(mode).replace(".", "_"),
+            upload_mode = mode
+        )
+
 def test_upload_file_without_mounting(custom_config : CustomConfig) -> None:
     _hcp_h = custom_config.hcp_h 
     _without_mounting(_hcp_h, HCPHandler.upload_file)
@@ -118,8 +125,6 @@ def test_get_file_in_sub_directory(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
     assert custom_config.hcp_h.object_exists(custom_config.test_file_path) 
     assert custom_config.hcp_h.get_object(custom_config.test_file_path) 
-
-from icecream import ic
 
 def test_download_file(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
@@ -215,6 +220,8 @@ def test_delete_file(custom_config : CustomConfig) -> None:
     test_mount_bucket(custom_config)
     custom_config.hcp_h.delete_object(custom_config.test_file_path) 
     custom_config.hcp_h.delete_object(custom_config.test_file_path + "_no_progress_bar")
+    for mode in HCPHandler.UploadMode:
+        custom_config.hcp_h.delete_object(custom_config.test_file_path + "_" + str(mode).replace(".", "_"))
     custom_config.hcp_h.delete_object("a_sub_directory/a_file") 
     custom_config.hcp_h.delete_object("a_sub_directory") 
 


### PR DESCRIPTION
## Contents

### Summary
This pull request introduces significant changes to the upload functionality in the `NGPIris` project, specifically adding new upload modes and enhancing the configuration options for file uploads. The most important changes include the addition of an `UploadMode` enum, the introduction of an `equal_parts` option, and updates to the `upload_file` and `upload_folder` methods to support these new features.

Enhancements to upload functionality:

* [`NGPIris/cli/__init__.py`](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL82-R99): Replaced the `--simple_upload` option with a new `--upload_mode` option that allows choosing between `STANDARD`, `SIMPLE`, and `EQUAL_PARTS` upload modes. Added a new `--equal_parts` option to specify the number of parts to split each file into when using the `EQUAL_PARTS` mode. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL82-R99) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR109-R114) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL106-R130)

* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR45): Introduced an `UploadMode` enum to define the different upload modes. Updated the `upload_file` and `upload_folder` methods to accept the `upload_mode` and `equal_parts` parameters, and implemented logic to handle these new options. [[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR45) [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR473-R479) [[3]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR492-R501) [[4]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL502-R551) [[5]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR563-R572) [[6]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL566-R586)

### The What
The simple upload option needed to be reworked

### The Why
Because some file uploads would misbehave and other options were needed

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
