### PR TITLE
`5.4.3`

### DIFF
--- a/NGPIris/hci/hci.py
+++ b/NGPIris/hci/hci.py
@@ -132,3 +132,28 @@ class HCIHandler:
             self.token, 
             self.use_ssl
         ).json())
+
+    def query(self, index_name : str, query_string : str = "", facets : list[str] = []) -> dict:
+        """
+        Make a query to the HCI based on the parameters of this method
+
+        :param index_name: Name of the index
+        :type index_name: str
+
+        :param query_string: The Solr query string. Defaults to the empty string
+        :type query_string: str, optional
+
+        :param facets: List of facets that should be returned included in the response. Defaults to []
+        :type facets: list[str], optional
+        
+        :return: The response in the form of a dictionary 
+        :rtype: dict
+        """
+        facetRequests = [{"fieldName" : facet } for facet in facets]
+        return self.raw_query(
+            {
+                "indexName" : index_name,
+                "queryString" : query_string,
+                "facetRequests" : facetRequests
+            }
+        )

--- a/NGPIris/hci/hci.py
+++ b/NGPIris/hci/hci.py
@@ -94,7 +94,7 @@ class HCIHandler:
         
         return {}
 
-    def raw_query(self, query_dict : dict[str, str]) -> dict:
+    def raw_query(self, query_dict : dict[str, str | list | dict]) -> dict:
         """
         Make query to an HCI index, with a dictionary
 

--- a/NGPIris/hci/hci.py
+++ b/NGPIris/hci/hci.py
@@ -26,11 +26,13 @@ class HCIHandler:
         """
         credentials_handler = CredentialsHandler(credentials_path)
         self.hci = credentials_handler.hci
+        
         self.username = self.hci["username"]
         self.password = self.hci["password"]
         self.address = self.hci["address"]
         self.auth_port = self.hci["auth_port"]
         self.api_port = self.hci["api_port"]
+
         self.token = ""
 
         self.use_ssl = use_ssl

--- a/NGPIris/hci/hci.py
+++ b/NGPIris/hci/hci.py
@@ -99,7 +99,7 @@ class HCIHandler:
         Make query to an HCI index, with a dictionary
 
         :param query_dict: Dictionary consisting of the query
-        :type query_dict: dict[str, str]
+        :type query_dict: dict[str, str | list | dict]
 
         :return: Dictionary containing the raw query
         :rtype: dict

--- a/NGPIris/hci/helpers.py
+++ b/NGPIris/hci/helpers.py
@@ -44,7 +44,7 @@ def get_index_response(address : str, api_port : str, token : str, use_ssl : boo
     return response
 
 def get_query_response(
-        query_dict : dict[str, str], 
+        query_dict : dict[str, str | list | dict], 
         address : str, 
         api_port : str, 
         token : str, 
@@ -55,7 +55,7 @@ def get_query_response(
     Retrieve the query response given the address, API port and token.
 
     :param query_dict: The query dictionary
-    :type query_dict: dict[str, str]
+    :type query_dict: dict[str, str | list | dict]
 
     :param address: The address where request is to be made
     :type address: str
@@ -79,7 +79,7 @@ def get_query_response(
         raise RuntimeError("Field indexName is missing in the query dictionary")
 
     url     : str            = "https://" + address + ":" + api_port + "/api/search/query/" + path_extension
-    query   : dict[str, str] = query_dict
+    query   : dict[str, str | list | dict] = query_dict
     headers : dict[str, str] = {
         "Content-Type": "application/json",
         "Accept": "application/json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.4.2"
+version = "5.4.3.dev1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.4.3.dev1"
+version = "5.4.3"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -26,10 +26,11 @@ def test_fail_index_look_up() -> None:
 def test_make_simple_raw_query() -> None:
     list_of_indexes = hci_h.list_index_names()
     arbitrary_index = list_of_indexes[randint(0, len(list_of_indexes) - 1)]
-    query = {
-        "indexName" : arbitrary_index
-    }
-    result = hci_h.raw_query(query)
+    result = hci_h.raw_query(
+        {
+            "indexName" : arbitrary_index
+        }
+    )
     assert result["indexName"] == arbitrary_index
 
 def test_raw_query_with_results() -> None:


### PR DESCRIPTION
## Contents

### Summary
This pull request introduces several enhancements and updates to the `NGPIris` project, including improvements to type annotations for query dictionaries, the addition of a new `query` method in the `hci.py` module, and updates to the project version. These changes aim to improve functionality, maintainability, and clarity in the codebase.

### Enhancements to type annotations:
* Updated type annotations for `query_dict` in the `raw_query` method in `NGPIris/hci/hci.py` to support `str`, `list`, and `dict` types.
* Updated type annotations for `query_dict` in the `get_query_response` method in `NGPIris/hci/helpers.py` to support `str`, `list`, and `dict` types. [[1]](diffhunk://#diff-0a8d1027537aba70c95bfeba97a4650638b36a3c8f8ea7c7c4b9a56139ec1558L47-R47) [[2]](diffhunk://#diff-0a8d1027537aba70c95bfeba97a4650638b36a3c8f8ea7c7c4b9a56139ec1558L58-R58) [[3]](diffhunk://#diff-0a8d1027537aba70c95bfeba97a4650638b36a3c8f8ea7c7c4b9a56139ec1558L82-R82)

### Addition of new query functionality:
* Added a new `query` method in `NGPIris/hci/hci.py` to facilitate querying HCI indexes with parameters for index name, query string, and facets.

### Project version update:
* Incremented the project version from `5.4.2` to `5.4.3` in `pyproject.toml`.

### Test updates:
* Refactored the `test_make_simple_raw_query` test in `tests/test_hci.py` to directly pass the query dictionary to `raw_query` instead of defining it separately.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
