### PR TITLE
Dev hci test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.4.3"
+version = "5.4.4.dev1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/tests/test_conf_template.ini
+++ b/tests/test_conf_template.ini
@@ -5,3 +5,8 @@ credentials_path =
 test_bucket = 
 test_file_path = tests/data/80MB_test_file
 result_path = tests/data/results/
+
+[HCI_tests]
+test_index = 
+query_string = 
+facets = 

--- a/tests/test_conf_template.ini
+++ b/tests/test_conf_template.ini
@@ -9,4 +9,4 @@ result_path = tests/data/results/
 [HCI_tests]
 test_index = 
 query_string = 
-facets = 
+test_facet = 

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -1,8 +1,6 @@
 
 from conftest import CustomConfig
 from random import randint
-from json import dump
-from os import remove
 
 def test_list_index_names_type(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -1,6 +1,7 @@
 
 from conftest import CustomConfig
 from random import randint
+from icecream import ic
 
 def test_list_index_names_type(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()
@@ -43,3 +44,38 @@ def test_make_query(custom_config : CustomConfig):
     custom_config.hci_h.query(
         custom_config.test_index
     )
+
+def test_make_query_with_query_string(custom_config : CustomConfig):
+    custom_config.hci_h.request_token()
+    custom_config.hci_h.query(
+        custom_config.test_index,
+        custom_config.query_string
+    )
+
+def test_make_query_with_query_string_and_facet(custom_config : CustomConfig):
+    custom_config.hci_h.request_token()
+    if custom_config.test_facet:
+        custom_config.hci_h.query(
+            custom_config.test_index,
+            custom_config.query_string,
+            [custom_config.test_facet]
+        )
+    else: 
+        custom_config.hci_h.query(
+            custom_config.test_index,
+            custom_config.query_string,
+            []
+        )
+
+def test_make_query_with_facet(custom_config : CustomConfig):
+    custom_config.hci_h.request_token()
+    if custom_config.test_facet:
+        custom_config.hci_h.query(
+            custom_config.test_index,
+            facets = [custom_config.test_facet]
+        )
+    else:
+        custom_config.hci_h.query(
+            custom_config.test_index,
+            facets = []
+        )

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -1,73 +1,47 @@
 
-from configparser import ConfigParser
-from NGPIris.hci import HCIHandler
+from conftest import CustomConfig
 from random import randint
 from json import dump
 from os import remove
 
-ini_config = ConfigParser()
-ini_config.read("tests/test_conf.ini")
-
-hci_h = HCIHandler(ini_config.get("General", "credentials_path"))
-hci_h.request_token()
-
-def test_list_index_names_type() -> None:
-    list_of_indexes = hci_h.list_index_names()
+def test_list_index_names_type(custom_config : CustomConfig) -> None:
+    custom_config.hci_h.request_token()
+    list_of_indexes = custom_config.hci_h.list_index_names()
     assert type(list_of_indexes) is list
 
-def test_look_up_all_indexes() -> None:
-    list_of_indexes = hci_h.list_index_names()
+def test_look_up_all_indexes(custom_config : CustomConfig) -> None:
+    custom_config.hci_h.request_token()
+    list_of_indexes = custom_config.hci_h.list_index_names()
     for index in list_of_indexes:
-        assert hci_h.look_up_index(index)
+        assert custom_config.hci_h.look_up_index(index)
 
-def test_fail_index_look_up() -> None:
-    assert not hci_h.look_up_index("anIndexThatDoesNotExist")
+def test_fail_index_look_up(custom_config : CustomConfig) -> None:
+    custom_config.hci_h.request_token()    
+    assert not custom_config.hci_h.look_up_index("anIndexThatDoesNotExist")
     
-def test_make_simple_raw_query() -> None:
-    list_of_indexes = hci_h.list_index_names()
+def test_make_simple_raw_query(custom_config : CustomConfig) -> None:
+    custom_config.hci_h.request_token()
+    list_of_indexes = custom_config.hci_h.list_index_names()
     arbitrary_index = list_of_indexes[randint(0, len(list_of_indexes) - 1)]
-    result = hci_h.raw_query(
+    result = custom_config.hci_h.raw_query(
         {
             "indexName" : arbitrary_index
         }
     )
     assert result["indexName"] == arbitrary_index
 
-def test_raw_query_with_results() -> None:
-    query = {
-        "indexName" : "Parsed_VCF_Index",
-        "facetRequests" : [
-            {
-                "fieldName" : "ref"
-            },
-            {
-                "fieldName" : "alt"
-            }
-        ]
-    }
-    parsed_VCF_index_result : list = hci_h.raw_query(query)["facets"]
-    for i in range(len(parsed_VCF_index_result)):
-        assert parsed_VCF_index_result[i]["termCounts"] # Assert if the result is not empty
-
-def test_fail_raw_query() -> None:
+def test_fail_raw_query(custom_config : CustomConfig) -> None:
+    custom_config.hci_h.request_token()
     query = {}
     try:
-        hci_h.raw_query(query)
+        custom_config.hci_h.raw_query(query)
     except:
         assert True
     else: # pragma: no cover
         assert False
 
-def test_make_simple_raw_query_from_JSON() -> None:
-    list_of_indexes = hci_h.list_index_names()
-    arbitrary_index = list_of_indexes[randint(0, len(list_of_indexes) - 1)]
-    path = "tests/data/json_test_query.json"
-    with open(path, "w") as f:
-        query = {
-            "indexName": arbitrary_index
-        }
-        dump(query, f, indent = 4)
-    result = hci_h.raw_query_from_JSON(path)
-    assert result["indexName"] == arbitrary_index
-    remove(path)    
-    
+def test_make_query(custom_config : CustomConfig):
+    custom_config.hci_h.request_token()
+    custom_config.hci_h.query(
+        custom_config.test_index
+    )

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -1,7 +1,6 @@
 
 from conftest import CustomConfig
 from random import randint
-from icecream import ic
 
 def test_list_index_names_type(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -38,20 +38,20 @@ def test_fail_raw_query(custom_config : CustomConfig) -> None:
     else: # pragma: no cover
         assert False
 
-def test_make_query(custom_config : CustomConfig):
+def test_make_query(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()
     custom_config.hci_h.query(
         custom_config.test_index
     )
 
-def test_make_query_with_query_string(custom_config : CustomConfig):
+def test_make_query_with_query_string(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()
     custom_config.hci_h.query(
         custom_config.test_index,
         custom_config.query_string
     )
 
-def test_make_query_with_query_string_and_facet(custom_config : CustomConfig):
+def test_make_query_with_query_string_and_facet(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()
     if custom_config.test_facet:
         custom_config.hci_h.query(
@@ -66,7 +66,7 @@ def test_make_query_with_query_string_and_facet(custom_config : CustomConfig):
             []
         )
 
-def test_make_query_with_facet(custom_config : CustomConfig):
+def test_make_query_with_facet(custom_config : CustomConfig) -> None:
     custom_config.hci_h.request_token()
     if custom_config.test_facet:
         custom_config.hci_h.query(


### PR DESCRIPTION
## Contents


### Summary
This pull request introduces enhancements to the test framework and functionality for the `NGPIris` project, including support for the `HCIHandler`, integration of new configuration options, and refactoring of test cases to improve maintainability and scalability.

### Framework Enhancements:
* Added support for `HCIHandler` in `tests/conftest.py`, including dynamic configuration setup and property access for `hci_h`. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R6-R9) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R21-R25) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R57-R65)
* Updated cleanup logic in `tests/conftest.py` to ensure proper handling of paths using `Path` objects.

### Configuration Updates:
* Extended `tests/test_conf_template.ini` to include a new `[HCI_tests]` section with placeholders for `test_index`, `query_string`, and `test_facet`.

### Test Refactoring:
* Refactored `tests/test_hci.py` to use the new `CustomConfig` class for accessing `HCIHandler` and configuration attributes dynamically, replacing hardcoded initialization logic. Added new test cases to cover query functionality with various parameters.

### Version Update:
* Updated the project version in `pyproject.toml` to `5.4.4.dev1` for development purposes.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
