### PR TITLE
127 feature request implement credentials prompt

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -140,11 +140,11 @@ def shell_env(context : Context, credentials_path : str, shell : str):
     click.echo("Copy and paste the following command in order to set your environment variable:")
     match shell:
         case "bash":
-            pass
+            pass # TODO
         case "fish":
             click.echo("set -x NGPIRIS_CREDENTIALS_PATH " + credentials_path)
         case "zsh":
-            pass
+            pass # TODO
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -129,7 +129,11 @@ def shell_env(context : Context, credentials_path : str, shell : str):
     NGP IRIS will look for an enviroment variable called 
     `NGPIRIS_CREDENTIALS_PATH` when authenicating. This command returns a 
     shell command that sets the `NGPIRIS_CREDENTIALS_PATH` enviroment variable 
-    depending on your shell.
+    depending on your shell. 
+    
+    NOTE: The enviroment variable will only last for this 
+    shell session, but you could set the value of `NGPIRIS_CREDENTIALS_PATH`
+    permanently via other commands if you wish to do so. 
 
     CREDENTIALS PATH is the either absolute or relative path to your credentials 
     JSON file
@@ -140,11 +144,11 @@ def shell_env(context : Context, credentials_path : str, shell : str):
     click.echo("Copy and paste the following command in order to set your environment variable:")
     match shell:
         case "bash":
-            pass # TODO
+            click.echo("export NGPIRIS_CREDENTIALS_PATH=" + credentials_path)
         case "fish":
             click.echo("set -x NGPIRIS_CREDENTIALS_PATH " + credentials_path)
         case "zsh":
-            pass # TODO
+            click.echo("export NGPIRIS_CREDENTIALS_PATH=" + credentials_path)
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -45,7 +45,7 @@ def add_trailing_slash(path : str) -> str:
 @click.option(
     "-tc", 
     "--transfer_config", 
-    help = "Use a custom transfer config for uploads or downloads", 
+    help = "Path for using a custom transfer config for uploads or downloads", 
 )
 @click.version_option(package_name = "NGPIris")
 @click.pass_context

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -109,6 +109,44 @@ def cli(context : Context, credentials : str, debug : bool, transfer_config : st
     """
 
 @cli.command()
+@click.argument(
+    "credentials_path", 
+    required = False
+)
+@click.option(
+    "-s",
+    "--shell", 
+    type = click.Choice(
+        ["bash", "fish", "zsh"],
+        case_sensitive = False
+    ),
+    help = "Allows for selection of shell that the produced command should support",
+    default = "bash"
+)
+@click.pass_context
+def shell_env(context : Context, credentials_path : str, shell : str):
+    """
+    NGP IRIS will look for an enviroment variable called 
+    `NGPIRIS_CREDENTIALS_PATH` when authenicating. This command returns a 
+    shell command that sets the `NGPIRIS_CREDENTIALS_PATH` enviroment variable 
+    depending on your shell.
+
+    CREDENTIALS PATH is the either absolute or relative path to your credentials 
+    JSON file
+    """
+    if not credentials_path:
+        click.prompt("Please enter the path to your credentials file")
+    
+    click.echo("Copy and paste the following command in order to set your environment variable:")
+    match shell:
+        case "bash":
+            pass
+        case "fish":
+            click.echo("set -x NGPIRIS_CREDENTIALS_PATH " + credentials_path)
+        case "zsh":
+            pass
+
+@cli.command()
 @click.argument("bucket")
 @click.argument("source")
 @click.argument("destination")

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -69,7 +69,7 @@ class HCPHandler:
             self.endpoint = "https://" + self.hcp["endpoint"]
             self.aws_access_key_id = self.hcp["aws_access_key_id"]
             self.aws_secret_access_key = self.hcp["aws_secret_access_key"]
-        elif type(credentials) is dict[str, str]:
+        elif type(credentials) is dict:
             self.endpoint = "https://" + credentials["endpoint"]
             self.aws_access_key_id = credentials["aws_access_key_id"]
             self.aws_secret_access_key = credentials["aws_secret_access_key"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.4.4.dev1"
+version = "5.5.0"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",


### PR DESCRIPTION
## Contents

### The What
Implementation of credentials prompt as per issue #127 

### The How
The `HCPHandler` class was rewritten to be able to handle two ways of ingesting credentials: either as a `str` (the path to a credentials file as before) or as a `dict` with the appropriate HCP credentials. The CLI commands were edited to reflect this change. 

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
