### PR TITLE
128 feature request reverse technical and simple stdout

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -350,15 +350,8 @@ def list_objects(context : Context, bucket : str, path : str, pagination : bool,
     default = False,
     is_flag = True
 )
-@click.option(
-    "-v", 
-    "--verbose", 
-    help = "Get a verbose output of files. Default value is False, since it might be slower", 
-    default = False,
-    is_flag = True
-)
 @click.pass_context
-def simple_search(context : Context, bucket : str, search_string : str, case_sensitive : bool, verbose : bool):
+def simple_search(context : Context, bucket : str, search_string : str, case_sensitive : bool):
     """
     Make simple search using substrings in a bucket/namespace on the HCP.
 
@@ -372,8 +365,7 @@ def simple_search(context : Context, bucket : str, search_string : str, case_sen
     hcph : HCPHandler = get_HCPHandler(context)
     hcph.mount_bucket(bucket)
     list_of_results = hcph.search_in_bucket(
-        search_string, 
-        name_only = (not verbose), 
+        search_string,  
         case_sensitive = case_sensitive
     )
     click.echo("Search results:")
@@ -391,26 +383,19 @@ def simple_search(context : Context, bucket : str, search_string : str, case_sen
     is_flag = True
 )
 @click.option(
-    "-v", 
-    "--verbose", 
-    help = "Get a verbose output of files. Default value is False, since it might be slower", 
-    default = False,
-    is_flag = True
-)
-@click.option(
     "-t", 
     "--threshold", 
     help = "Set the threshold for the fuzzy search score. Default value is 80", 
     default = 80
 )
 @click.pass_context
-def fuzzy_search(context : Context, bucket : str, search_string : str, case_sensitive : bool, verbose : bool, threshold : int):
+def fuzzy_search(context : Context, bucket : str, search_string : str, case_sensitive : bool, threshold : int):
     """
     Make a fuzzy search using a search string in a bucket/namespace on the HCP.
 
     NOTE: This command does not use the HCI. Instead, it uses the RapidFuzz 
-    library in order to find objects in the HCP. As such, this search might 
-    be slow.
+    library in order to find objects in the HCP. As such, this search might be 
+    slow.
 
     BUCKET is the name of the bucket in which to make the search.
 
@@ -420,7 +405,6 @@ def fuzzy_search(context : Context, bucket : str, search_string : str, case_sens
     hcph.mount_bucket(bucket)
     list_of_results = hcph.fuzzy_search_in_bucket(
         search_string, 
-        name_only = (not verbose), 
         case_sensitive = case_sensitive,
         threshold = threshold
     ) 

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -369,8 +369,10 @@ def simple_search(context : Context, bucket : str, search_string : str, case_sen
         case_sensitive = case_sensitive
     )
     click.echo("Search results:")
-    for result in list_of_results:
-        click.echo(result)
+    lt.stream(
+        list_of_results,
+        headers = "keys"
+    )
 
 @cli.command()
 @click.argument("bucket")
@@ -409,9 +411,10 @@ def fuzzy_search(context : Context, bucket : str, search_string : str, case_sens
         threshold = threshold
     ) 
     click.echo("Search results:")
-    for result in list_of_results:
-        click.echo(result) 
-
+    lt.stream(
+        list_of_results,
+        headers = "keys"
+    )
 @cli.command()
 @click.argument("bucket")
 @click.pass_context

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -14,9 +14,6 @@ from NGPIris.hcp import HCPHandler
 def get_HCPHandler(context : Context) -> HCPHandler:
     return context.obj["hcph"]
 
-def object_is_folder(object_path : str, hcph : HCPHandler) -> bool:
-    return (object_path[-1] == "/") and (hcph.get_object(object_path)["ContentLength"] == 0)
-
 def add_trailing_slash(path : str) -> str:
     if not path[-1] == "/":
         path += "/"
@@ -151,6 +148,9 @@ def download(context : Context, bucket : str, source : str, destination : str, f
 
     DESTINATION is the folder where the downloaded object or object folder is to be stored locally. 
     """
+    def object_is_folder(object_path : str, hcph : HCPHandler) -> bool:
+        return (object_path[-1] == "/") and (hcph.get_object(object_path)["ContentLength"] == 0)
+        
     hcph : HCPHandler = get_HCPHandler(context)
     hcph.mount_bucket(bucket)
     if not Path(destination).exists():

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -303,7 +303,7 @@ def list_objects(context : Context, bucket : str, path : str, name_only : bool, 
     PATH is an optional argument for where to list the objects
     """
     def simple_info(obj : dict[str, str]) -> str:
-        return obj["Key"] + " | Last modified: " + obj["LastModified"] + " | "
+        return obj["Key"] + " | Last modified: " + str(obj["LastModified"]) + " | "
 
     def list_objects_generator(hcph : HCPHandler, path : str, name_only : bool, files_only : bool, extended_information : bool) -> Generator[str, Any, None]:
         """

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -14,10 +14,6 @@ from NGPIris.hcp import HCPHandler
 def get_HCPHandler(context : Context) -> HCPHandler:
     return context.obj["hcph"]
 
-def format_list(list_of_things : list) -> str:
-    list_of_buckets = list(map(lambda s : s + "\n", list_of_things))
-    return "".join(list_of_buckets).strip("\n")
-
 def object_is_folder(object_path : str, hcph : HCPHandler) -> bool:
     return (object_path[-1] == "/") and (hcph.get_object(object_path)["ContentLength"] == 0)
 
@@ -261,7 +257,11 @@ def list_buckets(context : Context):
     List the available buckets/namespaces on the HCP.
     """
     hcph : HCPHandler = get_HCPHandler(context)
-    click.echo(format_list(hcph.list_buckets()))
+    click.echo(
+        "".join(
+            list(map(lambda s : s + "\n", hcph.list_buckets()))
+        ).strip("\n")
+    )
 
 @cli.command()
 @click.argument("bucket")

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -268,7 +268,7 @@ class HCPHandler:
         output_mode : ListObjectsOutputMode = ListObjectsOutputMode.EXTENDED,
         files_only : bool = False,
         list_all_bucket_objects : bool = False
-    ) -> Generator[dict, Any, None]:
+    ) -> Generator[dict[str, Any], Any, None]:
         """
         List all objects in the mounted bucket as a generator. If one wishes to 
         get the result as a list, use :py:function:`list` to type cast the generator
@@ -654,7 +654,11 @@ class HCPHandler:
         if key[-1] != "/":
             key += "/"
 
-        objects : list[str] = list(self.list_objects(key, name_only = True))
+        objects : list[str] = list(
+            obj["Key"] for obj in list(
+                self.list_objects(key, output_mode = HCPHandler.ListObjectsOutputMode.NAME_ONLY)
+            )
+        )
         objects.append(key) # Include the object "folder" path to be deleted
 
         if not objects:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "tqdm >= 4.66.2",
     "click >= 8.1.7",
     "bitmath == 1.3.3.1",
-    "tabulate == 0.9.0"
+    "lazy_table == 0.2.1",
+    "more-itertools == 10.7.0"
 ]
 authors = [
     {name = "Erik Brink", email = "erik.brink@gu.se"},


### PR DESCRIPTION
## Contents

### The What
Implementation of credentials prompt as per issue #128 

This pull request introduces significant changes to enhance the functionality and usability of the `NGPIris` CLI and its underlying HCP handler. The changes involve refactoring the codebase, adding new features, and improving output formatting. The most important updates include replacing verbose options with a new output mode system, integrating the `lazy_table` library for improved terminal output, and refactoring object listing and search functionalities for better flexibility and readability.

### The How
The CLI UX for object output (like when listing objects or searching for objects) has been improved. Objects are now displayed in a table for readability. There is now a flag `-e` for displaying more extensive metadata, meaning that all of that is hidden per default. 

#### CLI Enhancements and Refactoring:
* Removed the `verbose` and `name_only` options in CLI commands and replaced them with an `output_mode` parameter (`ListObjectsOutputMode`) that supports `SIMPLE`, `EXTENDED`, and `NAME_ONLY` modes. This simplifies the interface and improves flexibility ([[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR283-R315), [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR260-R284), [[3]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL294-R338)).
* Integrated the `lazy_table` library (`lt.stream`) for improved terminal output formatting in commands like `list_objects`, `simple_search`, and `fuzzy_search` ([[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL319-R341), [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL357-R375), [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL404-R417)).
* Added a new `--extended-information` option to the `list_objects` command for detailed metadata output ([NGPIris/cli/__init__.pyR283-R315](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR283-R315)).

#### Codebase Simplification:

* Refactored the `list_objects` method in `HCPHandler` to use a unified generator with the new `output_mode` parameter, reducing redundancy and improving maintainability ([NGPIris/hcp/hcp.pyL294-R338](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL294-R338)).
* Removed redundant helper functions such as `format_list` and `_list_objects_generator` in `NGPIris/cli/__init__.py`, and inlined their functionality where needed ([[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR9-L32), [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL273-L284)).

#### Search Functionality Improvements:

* Updated `search_in_bucket` and `fuzzy_search_in_bucket` to remove the `name_only` parameter and rely on the new `output_mode` system for consistency ([[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL660), [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL713-R744)).
* Optimized `fuzzy_search_in_bucket` by using `more-itertools.peekable` for efficient handling of object lists during fuzzy matching ([NGPIris/hcp/hcp.pyL713-R744](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL713-R744)).

#### Dependency Updates:

* Added `lazy_table` (v0.2.1) for enhanced table rendering and `more-itertools` (v10.7.0) for improved iterable handling ([pyproject.tomlL14-R15](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L14-R15)).

These changes collectively improve the usability, performance, and maintainability of the `NGPIris` CLI and its associated HCP handler.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
