### PR TITLE
130 feature request deletion of bucketnamespace via cli

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -573,5 +573,3 @@ def iris_generate_credentials_file(path : str, name : str):
         
     with open(file_path, "w") as f:
         dump(credentials_dict, f, indent = 4)
-
-    

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -298,7 +298,7 @@ def delete_object(context : Context, bucket : str, object : str, dry_run : bool)
     hcph : HCPHandler = create_HCPHandler(context)
     hcph.mount_bucket(bucket)
     if not dry_run:
-        hcph.delete_object(object)
+        click.echo(hcph.delete_object(object))
     else: 
         click.echo("This command would delete:")
         click.echo(list(hcph.list_objects(object))[0])
@@ -324,7 +324,7 @@ def delete_folder(context : Context, bucket : str, folder : str, dry_run : bool)
     hcph : HCPHandler = create_HCPHandler(context)
     hcph.mount_bucket(bucket)
     if not dry_run:
-        hcph.delete_folder(folder)
+        click.echo(hcph.delete_folder(folder))
     else:
         click.echo("By deleting \"" + folder + "\", the following objects would have been deleted (not including objects in sub-folders):")
         for obj in hcph.list_objects(folder):
@@ -342,7 +342,7 @@ def delete_folder(context : Context, bucket : str, folder : str, dry_run : bool)
 def delete_bucket(context : Context, bucket : str, dry_run : bool):
     hcph : HCPHandler = create_HCPHandler(context)
     if not dry_run:
-        hcph.delete_bucket(bucket)
+        click.echo(hcph.delete_bucket(bucket))
     else:
         click.echo("This command would have deleted the bucket called \"" + bucket + "\"")
 

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -511,6 +511,7 @@ def fuzzy_search(context : Context, bucket : str, search_string : str, case_sens
         list_of_results,
         headers = "keys"
     )
+
 @cli.command()
 @click.argument("bucket")
 @click.pass_context

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -331,6 +331,22 @@ def delete_folder(context : Context, bucket : str, folder : str, dry_run : bool)
             click.echo(obj)
 
 @cli.command()
+@click.argument("bucket")
+@click.option(
+    "-dr", 
+    "--dry_run", 
+    help = "Simulate the command execution without making actual changes. Useful for testing and verification", 
+    is_flag = True
+)
+@click.pass_context
+def delete_bucket(context : Context, bucket : str, dry_run : bool):
+    hcph : HCPHandler = create_HCPHandler(context)
+    if not dry_run:
+        hcph.delete_bucket(bucket)
+    else:
+        click.echo("This command would have deleted the bucket called \"" + bucket + "\"")
+
+@cli.command()
 @click.pass_context
 def list_buckets(context : Context):
     """

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -636,7 +636,9 @@ class HCPHandler:
                 Bucket = self.bucket_name,
                 Delete = deletion_dict
             )
-            result += dumps(response, indent = 4) + "\n"
+            
+            deleted_files = list(d["Key"] for d in response["Deleted"])
+            result += "The following was successfully deleted: \n" + "\n".join(deleted_files)
         
         if does_not_exist:
             result += "The following could not be deleted because they didn't exist: \n" + "\n".join(does_not_exist)
@@ -699,10 +701,11 @@ class HCPHandler:
         :return: The result of the deletion 
         :rtype: str 
         """
-        response : dict = self.s3_client.delete_bucket(
+        self.s3_client.delete_bucket(
             Bucket = bucket
         )
-        return dumps(response, indent = 4)
+        # If the deletion was not successful, `self.s3_client.delete_bucket` would have thrown an error 
+        return bucket + " was successfully deleted"
 
     @check_mounted
     def search_in_bucket(

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -212,8 +212,7 @@ class HCPHandler:
         try:
             response = dict(self.s3_client.head_bucket(Bucket = bucket_name))
         except EndpointConnectionError as e: # pragma: no cover
-            print(e)
-            raise VPNConnectionError("Please check your connection and that you have your VPN enabled")
+            raise e
         except ClientError as e:
             status_code = e.response["ResponseMetadata"].get("HTTPStatusCode", -1)
             match status_code:
@@ -431,7 +430,6 @@ class HCPHandler:
                     Config = self.transfer_config,
                 )
         except ClientError as e0: 
-            print(str(e0))
             raise e0
         except Exception as e: # pragma: no cover
             raise Exception(e)
@@ -613,14 +611,15 @@ class HCPHandler:
             )
 
     @check_mounted
-    def delete_objects(self, keys : list[str], verbose : bool = True) -> None:
-        """Delete a list of objects on the mounted bucket 
+    def delete_objects(self, keys : list[str]) -> str:
+        """
+        Delete a list of objects on the mounted bucket 
 
         :param keys: List of object names to be deleted
         :type keys: list[str]
 
-        :param verbose: Print the result of the deletion. Defaults to True
-        :type verbose: bool, optional
+        :return: The result of the deletion 
+        :rtype: str 
         """
         object_list = []
         does_not_exist = []
@@ -630,39 +629,41 @@ class HCPHandler:
             else:
                 does_not_exist.append(key)
 
+        result = ""
         if object_list:
             deletion_dict = {"Objects": object_list}
             response : dict = self.s3_client.delete_objects(
                 Bucket = self.bucket_name,
                 Delete = deletion_dict
             )
-            if verbose:
-                print(dumps(response, indent = 4))
-            
-        if verbose and does_not_exist:
-            print("The following could not be deleted because they didn't exist: \n" + "\n".join(does_not_exist))
+            result += dumps(response, indent = 4) + "\n"
+        
+        if does_not_exist:
+            result += "The following could not be deleted because they didn't exist: \n" + "\n".join(does_not_exist)
+        
+        return result
     
     @check_mounted
-    def delete_object(self, key : str, verbose : bool = True) -> None:
+    def delete_object(self, key : str) -> str:
         """
         Delete a single object in the mounted bucket
 
         :param key: The object to be deleted
         :type key: str
-        :param verbose: Print the result of the deletion. Defaults to True
-        :type verbose: bool, optional
+
+        :return: The result of the deletion 
+        :rtype: str 
         """
-        self.delete_objects([key], verbose = verbose)
+        return self.delete_objects([key])
 
     @check_mounted
-    def delete_folder(self, key : str, verbose : bool = True) -> None:
+    def delete_folder(self, key : str) -> str:
         """
         Delete a folder of objects in the mounted bucket. If there are subfolders, a RuntimeError is raised
 
         :param key: The folder of objects to be deleted
         :type key: str
-        :param verbose: Print the result of the deletion. defaults to True
-        :type verbose: bool, optional
+
         :raises RuntimeError: If there are subfolders, a RuntimeError is raised
         """
         if key[-1] != "/":
@@ -683,14 +684,14 @@ class HCPHandler:
         for object_path in objects:
             if (object_path[-1] == "/") and (not object_path == key): # `objects` might contain key, in which case everything is fine
                 raise RuntimeError("There are subfolders in this folder. Please remove these first, before deleting this one")
-        self.delete_objects(objects, verbose = verbose)
+        
+        return self.delete_objects(objects)
 
-    def delete_bucket(self, bucket : str, verbose : bool = True) -> None:
+    def delete_bucket(self, bucket : str) -> str:
         response : dict = self.s3_client.delete_bucket(
             Bucket = bucket
         )
-        if verbose:
-            print(dumps(response, indent = 4))
+        return dumps(response, indent = 4)
 
     @check_mounted
     def search_in_bucket(

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -637,7 +637,7 @@ class HCPHandler:
                 Delete = deletion_dict
             )
             if verbose:
-                print(dumps(response, indent=4))
+                print(dumps(response, indent = 4))
             
         if verbose and does_not_exist:
             print("The following could not be deleted because they didn't exist: \n" + "\n".join(does_not_exist))
@@ -684,6 +684,13 @@ class HCPHandler:
             if (object_path[-1] == "/") and (not object_path == key): # `objects` might contain key, in which case everything is fine
                 raise RuntimeError("There are subfolders in this folder. Please remove these first, before deleting this one")
         self.delete_objects(objects, verbose = verbose)
+
+    def delete_bucket(self, bucket : str, verbose : bool = True) -> None:
+        response : dict = self.s3_client.delete_bucket(
+            Bucket = bucket
+        )
+        if verbose:
+            print(dumps(response, indent = 4))
 
     @check_mounted
     def search_in_bucket(

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -665,6 +665,9 @@ class HCPHandler:
         :type key: str
 
         :raises RuntimeError: If there are subfolders, a RuntimeError is raised
+
+        :return: The result of the deletion 
+        :rtype: str
         """
         if key[-1] != "/":
             key += "/"
@@ -688,6 +691,14 @@ class HCPHandler:
         return self.delete_objects(objects)
 
     def delete_bucket(self, bucket : str) -> str:
+        """
+        Delete a specified bucket
+
+        :param bucket: The bucket to be deleted
+        :type bucket: str
+        :return: The result of the deletion 
+        :rtype: str 
+        """
         response : dict = self.s3_client.delete_bucket(
             Bucket = bucket
         )


### PR DESCRIPTION
## Contents


### The What
Implementation as per issue #130 

### Summary
This pull request introduces significant refactoring and enhancements to the `NGPIris` CLI and its HCP handler. Key changes include replacing the `get_HCPHandler` function with a more robust `create_HCPHandler` function, improving credential handling, and adding new CLI commands and options. The updates aim to enhance usability, maintainability, and functionality.

### Refactoring and Credential Handling:
* Modified the `HCPHandler` class to accept credentials as either a string (file path) or a dictionary, reducing dependency on external files (`NGPIris/hcp/hcp.py`, [NGPIris/hcp/hcp.pyL46-R77](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL46-R77)).

### CLI Enhancements:
* Added a new `shell_env` command to generate shell commands for setting the `NGPIRIS_CREDENTIALS_PATH` environment variable (`NGPIris/cli/__init__.py`, [NGPIris/cli/__init__.pyL59-R135](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL59-R135)).
* Introduced a `delete_bucket` command for removing entire buckets with optional dry-run functionality (`NGPIris/cli/__init__.py`, [NGPIris/cli/__init__.pyL257-L284](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL257-L284)).
* Enhanced the `list_objects` and `simple_search` commands to use the `lazy_table` library for better output formatting (`NGPIris/cli/__init__.py`, [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL319-R439) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL353-R473).

### Code Simplification:
* Removed redundant methods such as `_list_objects_generator` and `format_list`, consolidating logic into the new `list_objects_generator` function (`NGPIris/cli/__init__.py`, [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR9-R75) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR379-R411).
* Streamlined error handling in the `HCPHandler` class, such as raising exceptions directly instead of printing them (`NGPIris/hcp/hcp.py`, [NGPIris/hcp/hcp.pyL207-R215](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL207-R215)).

### Documentation and Usability:
* Updated CLI command descriptions and options to improve clarity, such as specifying `--transfer_config` as a path and adding short help messages for commands (`NGPIris/cli/__init__.py`, [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL48-R84) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL134-R199).

These changes collectively enhance the robustness and user experience of the `NGPIris` CLI while simplifying the underlying codebase.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
