### PR TITLE
107 feature request merge delete functions

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -92,7 +92,7 @@ def cli(context : Context, credentials : str, debug : bool, transfer_config : st
     CREDENTIALS refers to the path to the JSON credentials file.
     """
 
-@cli.command(short_help = "This command returns a shell command that sets the `NGPIRIS_CREDENTIALS_PATH` enviroment variable depending on your shell")
+@cli.command(short_help = "This command returns a shell command that sets the `NGPIRIS_CREDENTIALS_PATH` enviroment variable depending on your shell.")
 @click.argument(
     "credentials_path", 
     required = False
@@ -164,7 +164,7 @@ def shell_env(context : Context, credentials_path : str, shell : str):
 @click.pass_context
 def upload(context : Context, bucket : str, source : str, destination : str, dry_run : bool, upload_mode : str, equal_parts : int):
     """
-    Upload files to an HCP bucket/namespace. 
+    Upload files to a bucket/namespace on the HCP. 
     
     BUCKET is the name of the upload destination bucket.
 
@@ -196,7 +196,7 @@ def upload(context : Context, bucket : str, source : str, destination : str, dry
         else:
             hcph.upload_file(source, destination, upload_mode = upload_mode_choice, equal_parts = equal_parts)
 
-@cli.command(short_help = "Download a file or folder from an HCP bucket/namespace.")
+@cli.command(short_help = "Download a file or folder from a bucket/namespace on the HCP.")
 @click.argument("bucket")
 @click.argument("source")
 @click.argument("destination")
@@ -221,7 +221,7 @@ def upload(context : Context, bucket : str, source : str, destination : str, dry
 @click.pass_context
 def download(context : Context, bucket : str, source : str, destination : str, force : bool, ignore_warning : bool, dry_run : bool):
     """
-    Download a file or folder from an HCP bucket/namespace.
+    Download a file or folder from a bucket/namespace from the HCP.
 
     BUCKET is the name of the download source bucket.
 
@@ -303,7 +303,7 @@ def download(context : Context, bucket : str, source : str, destination : str, f
 @click.pass_context
 def delete(context : Context, bucket : str, object : str, dry_run : bool, mode : str):
     """
-    Delete objects in a HCP bucket/namespace.
+    Delete objects in a bucket/namespace on the HCP.
 
     BUCKET is the name of the bucket where the object to be deleted exist.
 
@@ -352,6 +352,9 @@ def delete(context : Context, bucket : str, object : str, dry_run : bool, mode :
 )
 @click.pass_context
 def delete_bucket(context : Context, bucket : str, dry_run : bool):
+    """
+    Delete a bucket/namespace on the HCP
+    """
     hcph : HCPHandler = create_HCPHandler(context)
     if not dry_run:
         click.echo(hcph.delete_bucket(bucket))

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -293,11 +293,11 @@ def download(context : Context, bucket : str, source : str, destination : str, f
         ["files", "folder"],
         case_sensitive = False
     ),
-    default = "files",
+    default = "folder",
     help = (
         "Allows for selection of between two modes: `files` or `folder`. " + 
         "`files` is for deleting individual files, while `folder` is for " + 
-        "deleting a folder. `files` is default mode"
+        "deleting a folder. `folder` is default mode"
     )
 )
 @click.pass_context

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -451,7 +451,7 @@ def list_objects(context : Context, bucket : str, path : str, pagination : bool,
             headers = "keys"
         )
 
-@cli.command(short_help = "Make simple search using substrings in a bucket/namespace on the HCP.")
+@cli.command(short_help = "Make a simple search using substrings in a bucket/namespace on the HCP.")
 @click.argument("bucket")
 @click.argument("search_string")
 @click.option(
@@ -464,7 +464,7 @@ def list_objects(context : Context, bucket : str, path : str, pagination : bool,
 @click.pass_context
 def simple_search(context : Context, bucket : str, search_string : str, case_sensitive : bool):
     """
-    Make simple search using substrings in a bucket/namespace on the HCP.
+    Make a simple search using substrings in a bucket/namespace on the HCP.
 
     NOTE: This command does not use the HCI. Instead, it uses a linear search of 
     all the objects in the HCP. As such, this search might be slow.

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -266,7 +266,7 @@ class HCPHandler:
     class ListObjectsOutputMode(Enum):
         SIMPLE = "simple"
         EXTENDED = "extended"
-        NAME_ONLY = "name_only"
+        MINIMAL = "minimal"
 
     @check_mounted
     def list_objects(
@@ -286,7 +286,7 @@ class HCPHandler:
             The upload mode of the transfer is any of the following:\n
                     HCPHandler.ListObjectsOutputMode.SIMPLE,\n
                     HCPHandler.ListObjectsOutputMode.EXTENDED,\n
-                    HCPHandler.ListObjectsOutputMode.NAME_ONLY\n
+                    HCPHandler.ListObjectsOutputMode.MINIMAL\n
             Default is EXTENDED
         :type output_mode: ListObjectsOutputMode, optional
         :param files_only: If True, only yield file objects. Defaults to False
@@ -327,8 +327,11 @@ class HCPHandler:
                                 "LastModified" : folder_object_metadata["LastModified"],
                                 "IsFile" : False,
                             }
-                        case HCPHandler.ListObjectsOutputMode.NAME_ONLY:
-                            yield {"Key" : folder_object["Prefix"]}   
+                        case HCPHandler.ListObjectsOutputMode.MINIMAL:
+                            yield {
+                                "Key" : folder_object["Prefix"],
+                                "IsFile" : False,
+                            }
             
             # Handle file objects
             for file_object in page.get("Contents", []):
@@ -345,8 +348,11 @@ class HCPHandler:
                                 "Size" : file_object["Size"],
                                 "IsFile" : file_object["IsFile"]
                             }
-                        case HCPHandler.ListObjectsOutputMode.NAME_ONLY:
-                            yield {"Key" : file_object["Key"]}
+                        case HCPHandler.ListObjectsOutputMode.MINIMAL:
+                            yield {
+                                "Key" : file_object["Key"],
+                                "IsFile" : file_object["IsFile"]
+                            }
                     
     @check_mounted
     def get_object(self, key : str) -> dict:
@@ -677,7 +683,7 @@ class HCPHandler:
             obj["Key"] for obj in 
             self.list_objects(
                 key, 
-                output_mode = HCPHandler.ListObjectsOutputMode.NAME_ONLY
+                output_mode = HCPHandler.ListObjectsOutputMode.MINIMAL
             )
         )
         objects.append(key) # Include the object "folder" path to be deleted
@@ -760,7 +766,7 @@ class HCPHandler:
         full_list_names_only = peekable(
             obj["Key"] for obj in 
             self.list_objects(
-                output_mode = HCPHandler.ListObjectsOutputMode.NAME_ONLY, 
+                output_mode = HCPHandler.ListObjectsOutputMode.MINIMAL, 
                 list_all_bucket_objects = True
             )
         )

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -727,7 +727,8 @@ class HCPHandler:
                 )
         
         return self.delete_objects(
-            list(obj["Key"] for obj in objects) + [key.rstrip("/")] # Include the object "folder" path to be deleted
+            list(obj["Key"] for obj in objects) + 
+            [key.rstrip("/")] # Include the object "folder" path to be deleted without trailing slash
         )
 
     def delete_bucket(self, bucket : str) -> str:

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -98,7 +98,9 @@ class HCPHandler:
                     if mapped_tenant:
                         self.tenant = mapped_tenant
                     else:
-                        raise RuntimeError("The provided tenant name, \"" + tenant + "\", could is not a valid tenant name. Hint: did you spell it correctly?")
+                        raise RuntimeError(
+                            "The provided tenant name, \"" + tenant + "\", is not a valid tenant name. Hint: did you spell it correctly?"
+                        )
                 else:
                     self.tenant = tenant
                 
@@ -106,7 +108,9 @@ class HCPHandler:
         
 
         if not self.tenant:
-            raise RuntimeError("Unable to parse endpoint, \"" + self.endpoint + "\". Make sure that you have entered the correct endpoint in your credentials JSON file. Hints:\n - The endpoint should *not* contain \"https://\" or port numbers\n - Is the endpoint spelled correctly?")
+            raise RuntimeError(
+                "Unable to parse endpoint, \"" + self.endpoint + "\". Make sure that you have entered the correct endpoint in your credentials JSON file. Hints:\n - The endpoint should *not* contain \"https://\" or port numbers\n - Is the endpoint spelled correctly?"
+            )
         self.base_request_url = self.endpoint + ":9090/mapi/tenants/" + self.tenant
         self.token = self.aws_access_key_id + ":" + self.aws_secret_access_key
         self.bucket_name = None
@@ -206,7 +210,9 @@ class HCPHandler:
         elif bucket_name:
             pass
         else:
-            raise RuntimeError("No bucket selected. Either use `mount_bucket` first or supply the optional `bucket_name` parameter for `test_connection`")
+            raise RuntimeError(
+                "No bucket selected. Either use `mount_bucket` first or supply the optional `bucket_name` parameter for `test_connection`"
+            )
         
         response = {}
         try:
@@ -217,9 +223,13 @@ class HCPHandler:
             status_code = e.response["ResponseMetadata"].get("HTTPStatusCode", -1)
             match status_code:
                 case 404:
-                    raise BucketNotFound("Bucket \"" + bucket_name + "\" was not found")
+                    raise BucketNotFound(
+                        "Bucket \"" + bucket_name + "\" was not found"
+                    )
                 case 403:
-                    raise BucketForbidden("Bucket \"" + bucket_name + "\" could not be accessed due to lack of permissions")
+                    raise BucketForbidden(
+                        "Bucket \"" + bucket_name + "\" could not be accessed due to lack of permissions"
+                    )
         except Exception as e: # pragma: no cover
             raise Exception(e)
             
@@ -410,7 +420,9 @@ class HCPHandler:
         try:
             self.get_object(key)
         except:
-            raise ObjectDoesNotExist("Could not find object", "\"" + key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\"")
+            raise ObjectDoesNotExist(
+                "Could not find object", "\"" + key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\""
+            )
         try:
             if show_progress_bar:
                 file_size : int = self.s3_client.head_object(Bucket = self.bucket_name, Key = key)["ContentLength"]
@@ -475,7 +487,9 @@ class HCPHandler:
         try:
             self.get_object(folder_key)
         except:
-            raise ObjectDoesNotExist("Could not find object", "\"" + folder_key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\"")
+            raise ObjectDoesNotExist(
+                "Could not find object", "\"" + folder_key + "\"", "in bucket", "\"" + str(self.bucket_name) + "\""
+            )
         if Path(local_folder_path).is_dir():
             current_download_size_in_bytes = Byte(0) # For tracking download limit
             (Path(local_folder_path) / Path(folder_key)).mkdir(parents = True) # Create "base folder"
@@ -493,10 +507,14 @@ class HCPHandler:
                 else: # If the object is a file
                     current_download_size_in_bytes += Byte(object["Size"])
                     if current_download_size_in_bytes >= download_limit_in_bytes and use_download_limit:
-                        raise DownloadLimitReached("The download limit was reached when downloading files")
+                        raise DownloadLimitReached(
+                            "The download limit was reached when downloading files"
+                        )
                     self.download_file(object["Key"], p.as_posix(), show_progress_bar = show_progress_bar)
         else:
-            raise NotADirectory(local_folder_path + " is not a directory")
+            raise NotADirectory(
+                local_folder_path + " is not a directory"
+            )
     
     class UploadMode(Enum):
         STANDARD = "standard"
@@ -539,10 +557,14 @@ class HCPHandler:
             key = file_name
 
         if "\\" in local_file_path:
-            raise RuntimeError("The \"\\\" character is not allowed in the file path")
+            raise RuntimeError(
+                "The \"\\\" character is not allowed in the file path"
+            )
 
         if self.object_exists(key):
-            raise ObjectAlreadyExist("The object \"" + key + "\" already exist in the mounted bucket")
+            raise ObjectAlreadyExist(
+                "The object \"" + key + "\" already exist in the mounted bucket"
+            )
         else:
             file_size : int = stat(local_file_path).st_size
 

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -740,9 +740,6 @@ class HCPHandler:
         :param search_string: Substring to be used in the search
         :type search_string: str
 
-        :param name_only: If True, yield only a the object names. If False, yield the full metadata about each object. Defaults to False.
-        :type name_only: bool, optional
-
         :param case_sensitive: Case sensitivity. Defaults to False
         :type case_sensitive: bool, optional
 

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -645,6 +645,8 @@ class HCPHandler:
         :param keys: List of object names to be deleted
         :type keys: list[str]
 
+        :raises RuntimeError: If the provided object is a folder object, then a `RuntimeError` is raised
+
         :return: The result of the deletion 
         :rtype: str 
         """
@@ -684,6 +686,8 @@ class HCPHandler:
 
         :param key: The object to be deleted
         :type key: str
+
+        :raises RuntimeError: If the provided object is a folder object, then a `RuntimeError` is raised
 
         :return: The result of the deletion 
         :rtype: str 


### PR DESCRIPTION
## Contents
Implementation of issue #107 

### Summary
This pull request introduces several improvements and refinements to the CLI and backend logic for managing objects in HCP buckets. The main focus is on enhancing the delete functionality by unifying file and folder deletion under a single command with mode selection, improving error messages, and making minor documentation and naming updates for clarity.

### CLI Improvements and Refactoring

* Unified the `delete_object` and `delete_folder` commands into a single `delete` command with a new `--mode` (`files` or `folder`) option, allowing users to specify what they want to delete and providing clearer error handling when the wrong mode is used. The dry-run output is also improved for both modes. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR289-R306) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR315-R343)
* Updated help texts and short descriptions for multiple commands (`upload`, `download`, `simple_search`, etc.) to more clearly describe their purpose and usage. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL167-R167) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL199-R199) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL224-R224) [[4]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL439-R454) [[5]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL452-R467)
* Added a missing docstring to the `delete_bucket` command for consistency.

### Backend Logic and Error Handling

* Improved error messages throughout `hcp.py` to provide more informative and user-friendly feedback, especially when parsing credentials, handling missing or forbidden buckets, and when objects or folders do not exist. [[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL101-R111) [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL209-R213) [[3]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL220-R230) [[4]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL407-R423) [[5]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL472-R490) [[6]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL490-R515) [[7]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL536-R565)
* Added explicit checks and raised `RuntimeError` when attempting to delete a folder object using the file deletion method, both in the CLI and in `delete_objects`/`delete_object`, to prevent accidental misuse. [[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR646-R659) [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eR688-R689)

### Code Cleanliness and Naming

* Renamed the `NAME_ONLY` output mode to `MINIMAL` in the `list_objects` method and updated related logic for clarity and consistency. [[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL269-R277) [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL289-R297) [[3]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL330-R342) [[4]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL348-R363)
* Removed unused imports (`VPNConnectionError`, `islice`) for code cleanliness. [[1]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL8) [[2]](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL24)

These changes collectively improve the usability, maintainability, and robustness of the CLI and backend for HCP object management.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
