### PR TITLE
NGP IRIS 5.5.1

### DIFF
--- a/NGPIris/hci/hci.py
+++ b/NGPIris/hci/hci.py
@@ -14,25 +14,32 @@ from urllib3 import disable_warnings
 from json import load
 
 class HCIHandler:
-    def __init__(self, credentials_path : str, use_ssl : bool = False) -> None:
+    def __init__(self, credentials : str | dict[str, str], use_ssl : bool = False) -> None:
         """
         Class for handling HCI requests.
 
-        :param credentials_path: Path to the JSON credentials file
-        :type credentials_path: str
+        :param credentials_path: If `credentials` is a `str`, then it will be interpreted as a path to the JSON credentials file. If `credentials` is a `dict`, then a dictionary with the appropriate HCI credentials is expected: ```{"username" : "", "password" : "", "address" : "", "auth_port" : "", "api_port" : ""}```
+        :type credentials_path: str | dict[str, str]
 
         :param use_ssl: Boolean choice between using SSL, defaults to False
         :type use_ssl: bool, optional
         """
-        credentials_handler = CredentialsHandler(credentials_path)
-        self.hci = credentials_handler.hci
+        if type(credentials) is str:
+            credentials_handler = CredentialsHandler(credentials)
+            self.hci = credentials_handler.hci
+            
+            self.username = self.hci["username"]
+            self.password = self.hci["password"]
+            self.address = self.hci["address"]
+            self.auth_port = self.hci["auth_port"]
+            self.api_port = self.hci["api_port"]
+        elif type(credentials) is dict:
+            self.username = credentials["username"]
+            self.password = credentials["password"]
+            self.address = credentials["address"]
+            self.auth_port = credentials["auth_port"]
+            self.api_port = credentials["api_port"]
         
-        self.username = self.hci["username"]
-        self.password = self.hci["password"]
-        self.address = self.hci["address"]
-        self.auth_port = self.hci["auth_port"]
-        self.api_port = self.hci["api_port"]
-
         self.token = ""
 
         self.use_ssl = use_ssl

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -55,7 +55,7 @@ class HCPHandler:
         Class for handling HCP requests.
 
         :param credentials: If `credentials` is a `str`, then it will be interpreted as a path to the JSON credentials file. If `credentials` is a `dict`, then a dictionary with the appropriate HCP credentials is expected: ```{"endpoint" : "", "aws_access_key_id" : "", "aws_secret_access_key" : "" }```
-        :type credentials: str | dict
+        :type credentials: str | dict[str, str]
         
         :param use_ssl: Boolean choice between using SSL, defaults to False
         :type use_ssl: bool, optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.5.0"
+version = "5.5.1"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",


### PR DESCRIPTION
## Contents
### Summary
This pull request introduces an enhancement to the `HCIHandler` class, allowing it to accept credentials either as a file path or directly as a dictionary. It also makes a minor documentation update to the `HCPHandler` class and bumps the package version to reflect these changes.

**Credential handling improvements:**

* [`NGPIris/hci/hci.py`](diffhunk://#diff-e334bf43bdbd743eb0493697c9bb82f235cd974a0a5970a481d68444d5cb4d7cL17-R41): Updated the `HCIHandler` constructor to accept credentials as either a file path (`str`) or a dictionary (`dict[str, str]`), and adjusted the logic to handle both cases. The docstring was updated accordingly.
* [`NGPIris/hcp/hcp.py`](diffhunk://#diff-ddfd5bfa9a022221a0f3b09ccc5c74d3044f271bfc635d749586b18a60934a5eL58-R58): Clarified the type annotation in the docstring for the `credentials` parameter to specify `dict[str, str]`.

**Versioning:**

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Bumped the package version from `5.5.0` to `5.5.1` to reflect these changes.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [ ] Code tested by @
