### PR TITLE
Dev cli improvements download

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import click
 import lazy_table as lt
-from bitmath import Byte, TiB
 from click.core import Context
 
 from NGPIris import HCPHandler
@@ -17,7 +16,6 @@ from NGPIris.cli.helpers import (
     download_folder,
     ensure_destination_dir,
     object_is_folder,
-    prompt_large_download,
 )
 
 
@@ -276,7 +274,8 @@ def download(  # noqa: PLR0913
                 )
             else:
                 click.echo(
-                    'This command would have downloaded the object "' + source + '"',
+                    'This command would have downloaded the object "'
+                    + source + '"',
                 )
         else:
             click.echo(

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from collections.abc import Generator
 from json import dump
@@ -8,89 +7,11 @@ from typing import Any
 import click
 import lazy_table as lt
 from bitmath import Byte, TiB
-from boto3 import set_stream_logger
 from click.core import Context
 
 from NGPIris import HCPHandler
 
-
-def add_trailing_slash(path: str) -> str:
-    """
-    Add a trailing slash ("/") to `path`.
-
-    :param path: Arbitrary string
-    :type path: str
-
-    :return: Arbitrary string with `"/"` at the end
-    :rtype: str
-    """
-    if not path[-1] == "/":
-        path += "/"
-    return path
-
-
-def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
-    """
-    Returns a `HCPHandler` based on the given command `context`.
-
-    :param context: The `click` context from the entered command
-    :type context: Context
-
-    :return: An `HCPHandler` instance based on the given command `context`
-    :rtype: HCPHandler
-    """
-    if context.parent:
-        parent_context = context.parent
-    else:
-        # Should never happen
-        click.echo(
-            """
-            Something went wrong with the subcommand and parent command relation
-            """,
-            err=True,
-        )
-        sys.exit(1)
-
-    credentials: str | None = parent_context.params.get("credentials")
-
-    if credentials:
-        hcp_credentials = credentials
-    elif os.environ.get("NGPIRIS_CREDENTIALS_PATH", None):
-        hcp_credentials = os.environ["NGPIRIS_CREDENTIALS_PATH"]
-    else:
-        endpoint: str = click.prompt(
-            "Please enter your tenant endpoint",
-        )
-
-        aws_access_key_id: str = click.prompt(
-            "Please enter your base64 hashed aws_access_key_id",
-        )
-
-        aws_secret_access_key: str = click.prompt(
-            "Please enter your md5 hashed aws_secret_access_key",
-            hide_input=True,
-            confirmation_prompt=True,
-        )
-
-        hcp_credentials = {
-            "endpoint": endpoint,
-            "aws_access_key_id": aws_access_key_id,
-            "aws_secret_access_key": aws_secret_access_key,
-        }
-
-    debug: bool | None = parent_context.params.get("debug")
-    transfer_config: str | None = parent_context.params.get("transfer_config")
-    if transfer_config:
-        hcp_h = HCPHandler(hcp_credentials, custom_config_path=transfer_config)
-    else:
-        hcp_h = HCPHandler(hcp_credentials)
-
-    if debug:
-        set_stream_logger(name="")
-        click.echo(hcp_h.transfer_config.__dict__)
-
-    return hcp_h
-
+from NGPIris.cli.helpers import add_trailing_slash, create_HCPHandler
 
 @click.group()
 @click.option(

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -10,8 +10,16 @@ from bitmath import Byte, TiB
 from click.core import Context
 
 from NGPIris import HCPHandler
+from NGPIris.cli.helpers import (
+    add_trailing_slash,
+    create_HCPHandler,
+    download_file,
+    download_folder,
+    ensure_destination_dir,
+    object_is_folder,
+    prompt_large_download,
+)
 
-from NGPIris.cli.helpers import add_trailing_slash, create_HCPHandler, object_is_folder, ensure_destination_dir, prompt_large_download, download_folder, download_file
 
 @click.group()
 @click.option(
@@ -250,7 +258,6 @@ def download(  # noqa: PLR0913
     DESTINATION is the folder where the downloaded object or object folder is to
     be stored locally.
     """
-
     hcp_h: HCPHandler = create_HCPHandler(context)
     hcp_h.mount_bucket(bucket)
 

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -275,7 +275,8 @@ def download(  # noqa: PLR0913
             else:
                 click.echo(
                     'This command would have downloaded the object "'
-                    + source + '"',
+                    + source
+                    + '"',
                 )
         else:
             click.echo(

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 from pathlib import Path
@@ -25,6 +24,7 @@ def add_trailing_slash(path: str) -> str:
         path += "/"
     return path
 
+
 def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
     """
     Returns a `HCPHandler` based on the given command `context`.
@@ -40,8 +40,10 @@ def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
     else:
         # Should never happen
         click.echo(
-            ("Something went wrong with the subcommand and parent"
-             "command relation"),
+            (
+                "Something went wrong with the subcommand and parent"
+                "command relation"
+            ),
             err=True,
         )
         sys.exit(1)
@@ -86,6 +88,7 @@ def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
 
     return hcp_h
 
+
 def object_is_folder(object_path: str, hcp_h: HCPHandler) -> bool:
     """
     Predicate for checking if an HCP object is a folder or not.
@@ -94,6 +97,7 @@ def object_is_folder(object_path: str, hcp_h: HCPHandler) -> bool:
         hcp_h.get_object(object_path)["ContentLength"] == 0
     )
 
+
 def ensure_destination_dir(destination: str) -> Path:
     """
     Ensure that `destination` exists and return it as a `Path`.
@@ -101,6 +105,7 @@ def ensure_destination_dir(destination: str) -> Path:
     dest_path = Path(destination)
     dest_path.mkdir(parents=True, exist_ok=True)
     return dest_path
+
 
 def prompt_large_download() -> None:
     """
@@ -112,7 +117,10 @@ def prompt_large_download() -> None:
     ):
         sys.exit("\nAborting download")
 
-def download_folder(source : str, destination_path : Path, ignore_warning : bool, hcp_h : HCPHandler):
+
+def download_folder(
+    source: str, destination_path: Path, ignore_warning: bool, hcp_h: HCPHandler
+):
     """
     Helper function to `download` for downloading a folder.
     """
@@ -129,14 +137,20 @@ def download_folder(source : str, destination_path : Path, ignore_warning : bool
 
     hcp_h.download_folder(prefix, destination_path.as_posix())
 
-def download_file(source : str, destination_path : Path, ignore_warning : bool, force : bool, hcp_h : HCPHandler):
+
+def download_file(
+    source: str,
+    destination_path: Path,
+    ignore_warning: bool,
+    force: bool,
+    hcp_h: HCPHandler,
+):
     """
     Helper function to `download` for downloading a file.
     """
     check_size_and_ignore_warning_flag = (
-        (Byte(hcp_h.get_object(source)["ContentLength"]) >= TiB(1)) and
-        (not ignore_warning)
-    )
+        Byte(hcp_h.get_object(source)["ContentLength"]) >= TiB(1)
+    ) and (not ignore_warning)
     if check_size_and_ignore_warning_flag:
         prompt_large_download()
 
@@ -144,6 +158,6 @@ def download_file(source : str, destination_path : Path, ignore_warning : bool, 
     if downloaded_source.exists() and not force:
         sys.exit(
             "Object already exists. If you wish to overwrite the existing file, "
-             "use the -f / --force option"
+            "use the -f / --force option"
         )
     hcp_h.download_file(source, downloaded_source.as_posix())

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -120,7 +120,7 @@ def prompt_large_download() -> None:
 
 def download_folder(
     source: str, destination_path: Path, ignore_warning: bool, hcp_h: HCPHandler
-):
+) -> None:
     """
     Helper function to `download` for downloading a folder.
     """
@@ -144,7 +144,7 @@ def download_file(
     ignore_warning: bool,
     force: bool,
     hcp_h: HCPHandler,
-):
+) -> None:
     """
     Helper function to `download` for downloading a file.
     """
@@ -157,7 +157,7 @@ def download_file(
     downloaded_source = Path(destination_path) / Path(source).name
     if downloaded_source.exists() and not force:
         sys.exit(
-            "Object already exists. If you wish to overwrite the existing file, "
-            "use the -f / --force option"
+            "Object already exists. If you wish to overwrite the existing file,"
+            " use the -f / --force option"
         )
     hcp_h.download_file(source, downloaded_source.as_posix())

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -127,7 +127,7 @@ def download_file(source : str, destination_path : Path, ignore_warning : bool, 
     downloaded_source = Path(destination_path) / Path(source).name
     if downloaded_source.exists() and not force:
         sys.exit(
-            """Object already exists. If you wish to overwrite the
-            existing file, use the -f / --force option"""
+            "Object already exists. If you wish to overwrite the existing file, "
+            + "use the -f / --force option"
         )
     hcp_h.download_file(source, downloaded_source.as_posix())

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -1,0 +1,84 @@
+
+import os
+import sys
+import click
+from click.core import Context
+from boto3 import set_stream_logger
+
+from NGPIris import HCPHandler
+
+def add_trailing_slash(path: str) -> str:
+    """
+    Add a trailing slash ("/") to `path`.
+
+    :param path: Arbitrary string
+    :type path: str
+
+    :return: Arbitrary string with `"/"` at the end
+    :rtype: str
+    """
+    if not path[-1] == "/":
+        path += "/"
+    return path
+
+def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
+    """
+    Returns a `HCPHandler` based on the given command `context`.
+
+    :param context: The `click` context from the entered command
+    :type context: Context
+
+    :return: An `HCPHandler` instance based on the given command `context`
+    :rtype: HCPHandler
+    """
+    if context.parent:
+        parent_context = context.parent
+    else:
+        # Should never happen
+        click.echo(
+            """
+            Something went wrong with the subcommand and parent command relation
+            """,
+            err=True,
+        )
+        sys.exit(1)
+
+    credentials: str | None = parent_context.params.get("credentials")
+
+    if credentials:
+        hcp_credentials = credentials
+    elif os.environ.get("NGPIRIS_CREDENTIALS_PATH", None):
+        hcp_credentials = os.environ["NGPIRIS_CREDENTIALS_PATH"]
+    else:
+        endpoint: str = click.prompt(
+            "Please enter your tenant endpoint",
+        )
+
+        aws_access_key_id: str = click.prompt(
+            "Please enter your base64 hashed aws_access_key_id",
+        )
+
+        aws_secret_access_key: str = click.prompt(
+            "Please enter your md5 hashed aws_secret_access_key",
+            hide_input=True,
+            confirmation_prompt=True,
+        )
+
+        hcp_credentials = {
+            "endpoint": endpoint,
+            "aws_access_key_id": aws_access_key_id,
+            "aws_secret_access_key": aws_secret_access_key,
+        }
+
+    debug: bool | None = parent_context.params.get("debug")
+    transfer_config: str | None = parent_context.params.get("transfer_config")
+    if transfer_config:
+        hcp_h = HCPHandler(hcp_credentials, custom_config_path=transfer_config)
+    else:
+        hcp_h = HCPHandler(hcp_credentials)
+
+    if debug:
+        set_stream_logger(name="")
+        click.echo(hcp_h.transfer_config.__dict__)
+
+    return hcp_h

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -87,16 +87,25 @@ def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
     return hcp_h
 
 def object_is_folder(object_path: str, hcp_h: HCPHandler) -> bool:
+    """
+    Predicate for checking if an HCP object is a folder or not.
+    """
     return (object_path.endswith("/")) and (
         hcp_h.get_object(object_path)["ContentLength"] == 0
     )
 
 def ensure_destination_dir(destination: str) -> Path:
+    """
+    Ensure that `destination` exists and return it as a `Path`.
+    """
     dest_path = Path(destination)
     dest_path.mkdir(parents=True, exist_ok=True)
     return dest_path
 
 def prompt_large_download() -> None:
+    """
+    Prompt for large downloads.
+    """
     if not click.confirm(
         "WARNING: You are about to download more than 1 TB of data. "
         "Is this your intention?"
@@ -104,6 +113,9 @@ def prompt_large_download() -> None:
         sys.exit("\nAborting download")
 
 def download_folder(source : str, destination_path : Path, ignore_warning : bool, hcp_h : HCPHandler):
+    """
+    Helper function to `download` for downloading a folder.
+    """
     prefix = "" if source == "/" else source
 
     cumulative_download_size = Byte(0)
@@ -118,6 +130,9 @@ def download_folder(source : str, destination_path : Path, ignore_warning : bool
     hcp_h.download_folder(prefix, destination_path.as_posix())
 
 def download_file(source : str, destination_path : Path, ignore_warning : bool, force : bool, hcp_h : HCPHandler):
+    """
+    Helper function to `download` for downloading a file.
+    """
     check_size_and_ignore_warning_flag = (
         (Byte(hcp_h.get_object(source)["ContentLength"]) >= TiB(1)) and
         (not ignore_warning)

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -96,15 +96,10 @@ def ensure_destination_dir(destination: str) -> Path:
     return dest_path
 
 def prompt_large_download() -> None:
-    click.echo(
-        """
-        WARNING: You are about to download more than 1 TB
-        of data. Is this your intention? [y/N]: 
-        """,  # noqa: W291
-        nl=False,
-    )
-    inp = click.getchar(echo=True)
-    if inp not in ["y", "Y"]:
+    if not click.confirm(
+        "WARNING: You are about to download more than 1 TB of data. " +
+        "Is this your intention?"
+    ):
         sys.exit("\nAborting download")
 
 def download_folder(source : str, destination_path : Path, ignore_warning : bool, hcp_h : HCPHandler):

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -1,13 +1,15 @@
 
 import os
 import sys
-import click
-from click.core import Context
-from boto3 import set_stream_logger
 from pathlib import Path
+
+import click
 from bitmath import Byte, TiB
+from boto3 import set_stream_logger
+from click.core import Context
 
 from NGPIris import HCPHandler
+
 
 def add_trailing_slash(path: str) -> str:
     """
@@ -38,9 +40,8 @@ def create_HCPHandler(context: Context) -> HCPHandler:  # noqa: N802
     else:
         # Should never happen
         click.echo(
-            """
-            Something went wrong with the subcommand and parent command relation
-            """,
+            ("Something went wrong with the subcommand and parent"
+             "command relation"),
             err=True,
         )
         sys.exit(1)
@@ -97,7 +98,7 @@ def ensure_destination_dir(destination: str) -> Path:
 
 def prompt_large_download() -> None:
     if not click.confirm(
-        "WARNING: You are about to download more than 1 TB of data. " +
+        "WARNING: You are about to download more than 1 TB of data. "
         "Is this your intention?"
     ):
         sys.exit("\nAborting download")
@@ -128,6 +129,6 @@ def download_file(source : str, destination_path : Path, ignore_warning : bool, 
     if downloaded_source.exists() and not force:
         sys.exit(
             "Object already exists. If you wish to overwrite the existing file, "
-            + "use the -f / --force option"
+             "use the -f / --force option"
         )
     hcp_h.download_file(source, downloaded_source.as_posix())


### PR DESCRIPTION
## Contents
This pull request refactors the CLI code for NGPIris by moving several helper functions out of `NGPIris/cli/__init__.py` into a new module, `NGPIris/cli/helpers.py`, and updating their usage throughout the CLI. This improves code organization, readability, and maintainability by separating concerns and reducing duplication.

### Refactoring and Code Organization

* Moved utility functions (`add_trailing_slash`, `create_HCPHandler`, `object_is_folder`, and download helpers) from `NGPIris/cli/__init__.py` to a new file `NGPIris/cli/helpers.py`, and updated their imports and usage in the CLI code. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL10-L92) [[2]](diffhunk://#diff-36cdf3b8c6b1e34e438bf5b83ab7128b2180dd030f28c237dca2d4d0789b0503R1-R163)
* Removed duplicate and inline implementations of helper logic from `__init__.py`, replacing them with calls to the new helper functions. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL10-L92) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL332-R268) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL400-R290)

### Download Logic Improvements

* Centralized the logic for checking if an object is a folder, ensuring destination directory creation, and handling large download warnings into dedicated helper functions for better clarity and reuse.
* Simplified the main `download` command flow by using the new helpers, making the code easier to follow and maintain. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL332-R268) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL400-R290)

### Minor Cleanups

* Removed unused imports and redundant code from `NGPIris/cli/__init__.py` as part of the refactor.

These changes collectively make the CLI codebase more modular and easier to extend or test in the future.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
