### PR TITLE
Dev cli improvements section commands

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -49,19 +49,8 @@ def cli(
     NGP Intelligence and Repository Interface Software, IRIS.
     """
 
-def section_command(section_name: str, *dargs, **dkwargs):
-    """
-    Helper decorator: @section_command("User Commands") instead of @cli.command(...)
-    """
-    def decorator(f):
-        cmd = click.command(*dargs, **dkwargs)(f)
-        cmd.section = section_name
-        cli.add_command(cmd)
-        return cmd
-    return decorator
-
-@section_command(
-    "Object commands",
+@cli.command(
+    section="Object commands",
     short_help="Upload a file or folder from a bucket/namespace on the HCP."
 )
 @click.argument("bucket")
@@ -167,8 +156,8 @@ def upload(  # noqa: PLR0913
             )
 
 
-@section_command(
-    "Object commands",
+@cli.command(
+    section="Object commands",
     short_help="Download a file or folder from a bucket/namespace on the HCP."
 )
 @click.argument("bucket")
@@ -251,8 +240,8 @@ def download(  # noqa: PLR0913
         download_file(source, destination_path, ignore_warning, force, hcp_h)
 
 
-@section_command(
-    "Object commands",
+@cli.command(
+    section="Object commands",
     short_help="Delete objects in a bucket/namespace on the HCP."
 )
 @click.argument("bucket")
@@ -348,8 +337,8 @@ def delete(
                 )
 
 
-@section_command(
-    "Bucket commands",
+@cli.command(
+    section="Bucket commands",
     short_help="Delete a bucket/namespace on the HCP."
 )
 @click.argument("bucket")
@@ -382,8 +371,8 @@ def delete_bucket(
         )
 
 
-@section_command(
-    "Bucket commands",
+@cli.command(
+    section="Bucket commands",
     short_help="List the available buckets/namespaces on the HCP."
 )
 @click.option(
@@ -415,8 +404,8 @@ def list_buckets(
 
 
 
-@section_command(
-    "Object commands",
+@cli.command(
+    section="Object commands",
     short_help="List the objects in a certain bucket/namespace on the HCP.",
 )
 @click.argument("bucket")
@@ -514,8 +503,8 @@ def list_objects(  # noqa: PLR0913
             headers="keys",
         )
 
-@section_command(
-    "Search commands",
+@cli.command(
+    section="Search commands",
     short_help=(
         "Make a simple search using substrings in a bucket/namespace on"
         "the HCP."
@@ -560,8 +549,8 @@ def simple_search(
     )
 
 
-@section_command(
-    "Search commands",
+@cli.command(
+    section="Search commands",
     short_help=(
         "Make a fuzzy search using a search string in a bucket/namespace"
         "on the HCP."
@@ -615,8 +604,8 @@ def fuzzy_search(
     )
 
 
-@section_command(
-    "Utility commands"
+@cli.command(
+    section="Utility commands"
 )
 @click.argument("bucket")
 @click.pass_context

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -18,8 +18,9 @@ from NGPIris.cli.helpers import (
     ensure_destination_dir,
     object_is_folder,
 )
-from NGPIris.hcp.exceptions import IsFolderObjectError, ObjectDoesNotExistError
 from NGPIris.cli.sections import SectionedGroup
+from NGPIris.hcp.exceptions import IsFolderObjectError, ObjectDoesNotExistError
+
 
 @click.group(cls=SectionedGroup)
 @click.option(

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -60,7 +60,10 @@ def section_command(section_name: str, *dargs, **dkwargs):
         return cmd
     return decorator
 
-@section_command("Object commands")
+@section_command(
+    "Object commands",
+    short_help="Upload a file or folder from a bucket/namespace on the HCP."
+)
 @click.argument("bucket")
 @click.argument("source")
 @click.argument("destination")
@@ -248,7 +251,10 @@ def download(  # noqa: PLR0913
         download_file(source, destination_path, ignore_warning, force, hcp_h)
 
 
-@cli.command()
+@section_command(
+    "Object commands",
+    short_help="Delete objects in a bucket/namespace on the HCP."
+)
 @click.argument("bucket")
 @click.argument("hcp_object")
 @click.option(
@@ -342,7 +348,10 @@ def delete(
                 )
 
 
-@cli.command()
+@section_command(
+    "Bucket commands",
+    short_help="Delete a bucket/namespace on the HCP."
+)
 @click.argument("bucket")
 @click.option(
     "-dr",
@@ -373,7 +382,10 @@ def delete_bucket(
         )
 
 
-@cli.command()
+@section_command(
+    "Bucket commands",
+    short_help="List the available buckets/namespaces on the HCP."
+)
 @click.option(
     "-o",
     "--output_mode",
@@ -403,7 +415,8 @@ def list_buckets(
 
 
 
-@cli.command(
+@section_command(
+    "Object commands",
     short_help="List the objects in a certain bucket/namespace on the HCP.",
 )
 @click.argument("bucket")
@@ -501,11 +514,12 @@ def list_objects(  # noqa: PLR0913
             headers="keys",
         )
 
-
-@cli.command(
-    short_help="""
-    Make a simple search using substrings in a bucket/namespace on the HCP.
-    """,
+@section_command(
+    "Search commands",
+    short_help=(
+        "Make a simple search using substrings in a bucket/namespace on"
+        "the HCP."
+    ),
 )
 @click.argument("bucket")
 @click.argument("search_string")
@@ -546,10 +560,12 @@ def simple_search(
     )
 
 
-@cli.command(
-    short_help="""
-    Make a fuzzy search using a search string in a bucket/namespace on the HCP.
-    """,
+@section_command(
+    "Search commands",
+    short_help=(
+        "Make a fuzzy search using a search string in a bucket/namespace"
+        "on the HCP."
+    ),
 )
 @click.argument("bucket")
 @click.argument("search_string")
@@ -599,7 +615,9 @@ def fuzzy_search(
     )
 
 
-@cli.command()
+@section_command(
+    "Utility commands"
+)
 @click.argument("bucket")
 @click.pass_context
 def test_connection(context: Context, bucket: str) -> None:

--- a/NGPIris/cli/sections.py
+++ b/NGPIris/cli/sections.py
@@ -1,0 +1,33 @@
+import click
+
+
+class SectionedGroup(click.Group):
+    """
+    A click.Group that prints commands grouped into sections.
+    """
+
+    def format_commands(self, ctx, formatter):
+        # Collect all visible commands
+        commands = []
+        for name in self.list_commands(ctx):
+            cmd = self.get_command(ctx, name)
+            if cmd is None or cmd.hidden:
+                continue
+            commands.append((name, cmd))
+
+        if not commands:
+            return
+
+        # Group by `section` attribute, defaulting to "Commands"
+        sections = {}
+        for name, cmd in commands:
+            section_name = getattr(cmd, "section", "Commands")
+            sections.setdefault(section_name, []).append((name, cmd))
+
+        # Render each section
+        for section_name, items in sections.items():
+            with formatter.section(section_name):
+                rows = []
+                for name, cmd in items:
+                    rows.append((name, cmd.get_short_help_str()))
+                formatter.write_dl(rows)

--- a/NGPIris/cli/sections.py
+++ b/NGPIris/cli/sections.py
@@ -1,10 +1,21 @@
+from collections.abc import Callable
+
 import click
 
 
 class SectionedGroup(click.Group):
-    """A click.Group that prints commands grouped into sections."""
+    """
+    A click.Group that prints commands grouped into sections.
+    """
 
-    def format_commands(self, ctx, formatter):
+    def format_commands(
+        self,
+        ctx : click.Context,
+        formatter: click.HelpFormatter
+    ) -> None:
+        """
+        Format commands such that commands are grouped in sections.
+        """
         # Collect all visible commands
         commands = []
         for name in self.list_commands(ctx):
@@ -30,9 +41,13 @@ class SectionedGroup(click.Group):
                     rows.append((name, cmd.get_short_help_str()))
                 formatter.write_dl(rows)
 
-    def command(self, *args, **kwargs):
+    def command(
+        self,
+        *args,
+        **kwargs
+    ) -> Callable[[Callable], click.Command] | click.Command:
         """
-        Override Group.command to accept a 'section' kwarg:
+        Override Group.command to accept a 'section' kwarg.
 
             @cli.command(section="User Commands")
             def add():
@@ -40,10 +55,10 @@ class SectionedGroup(click.Group):
         """
         section = kwargs.pop("section", None)
 
-        def decorator(f):
+        def decorator(f: Callable) -> click.Command:
             cmd = super(SectionedGroup, self).command(*args, **kwargs)(f)
             if section is not None:
-                cmd.section = section
+                cmd.section = section # pyright: ignore[reportAttributeAccessIssue]
             return cmd
 
         return decorator

--- a/NGPIris/cli/sections.py
+++ b/NGPIris/cli/sections.py
@@ -2,9 +2,7 @@ import click
 
 
 class SectionedGroup(click.Group):
-    """
-    A click.Group that prints commands grouped into sections.
-    """
+    """A click.Group that prints commands grouped into sections."""
 
     def format_commands(self, ctx, formatter):
         # Collect all visible commands
@@ -31,3 +29,21 @@ class SectionedGroup(click.Group):
                 for name, cmd in items:
                     rows.append((name, cmd.get_short_help_str()))
                 formatter.write_dl(rows)
+
+    def command(self, *args, **kwargs):
+        """
+        Override Group.command to accept a 'section' kwarg:
+
+            @cli.command(section="User Commands")
+            def add():
+                ...
+        """
+        section = kwargs.pop("section", None)
+
+        def decorator(f):
+            cmd = super(SectionedGroup, self).command(*args, **kwargs)(f)
+            if section is not None:
+                cmd.section = section
+            return cmd
+
+        return decorator

--- a/NGPIris/cli/sections.py
+++ b/NGPIris/cli/sections.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Any
 
 import click
 
@@ -41,11 +42,11 @@ class SectionedGroup(click.Group):
                     rows.append((name, cmd.get_short_help_str()))
                 formatter.write_dl(rows)
 
-    def command(
+    def command( # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         *args,
         **kwargs
-    ) -> Callable[[Callable], click.Command] | click.Command:
+    ) -> Callable[[Callable[..., Any]], click.Command] | click.Command:
         """
         Override Group.command to accept a 'section' kwarg.
 


### PR DESCRIPTION
## Contents
This pull request enhances the CLI by introducing command grouping and sectioned help output, making the CLI commands easier to navigate and understand. It does this by implementing a custom `SectionedGroup` for the CLI, updating command decorators to specify sections and improve help text, and removing an obsolete command.

**CLI Usability Improvements:**

* Added a new `SectionedGroup` class in `NGPIris/cli/sections.py` to allow commands to be grouped by section in the CLI help output, improving discoverability and organization.
* Modified the main CLI group in `NGPIris/cli/__init__.py` to use `SectionedGroup` instead of the default Click group.
* Updated all CLI command decorators in `NGPIris/cli/__init__.py` to specify a `section` and improved `short_help` text for clarity and consistency. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL52-L108) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL213-R162) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL295-R247) [[4]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL389-R344) [[5]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL420-R378) [[6]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR409) [[7]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL548-R512) [[8]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL594-R558) [[9]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL646-R610)

**Command Cleanup:**

* Removed the obsolete `shell_env` command, which set the `NGPIRIS_CREDENTIALS_PATH` environment variable, streamlining the CLI and reducing confusion.
