### PR TITLE
Fix CLI delete file bug

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -204,7 +204,7 @@ def delete(
     hcp_h.mount_bucket(bucket)
     if not dry_run:
         match mode:
-            case "files":
+            case "file":
                 try:
                     click.echo(hcp_h.delete_object(hcp_object))
                 except IsFolderObjectError:
@@ -231,7 +231,7 @@ def delete(
                     sys.exit(1)
     else:
         match mode:
-            case "files":
+            case "file":
                 click.echo(
                     'This command would have deleted the file object "'
                     + hcp_object


### PR DESCRIPTION
## Summary
This pull request makes a small but important correction to the `delete` command logic in `NGPIris/cli/__init__.py`, ensuring that the mode matches the intended singular form.

- Changed the match case from `"files"` to `"file"` in two locations within the `delete` function to correctly handle file deletion logic. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL207-R207) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL234-R234)

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
