### PR TITLE
Add prefixed file size units

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import click
 import lazy_table as lt
+from bitmath import SI, Byte
 from click.core import Context
 from tabulate import tabulate
 
@@ -381,11 +382,11 @@ def list_objects(  # noqa: PLR0913
     PATH is an optional argument for where to list the objects
     """
 
-    def list_objects_generator(
+    def list_objects_pagination_generator(
         hcp_h: HCPHandler,
         path: str,
-        files_only: bool,
         output_mode: HCPHandler.ListObjectsOutputMode,
+        files_only: bool,
     ) -> Generator[str, Any, None]:
         """
         Handle object list as a paginator that `click` can handle.
@@ -399,6 +400,24 @@ def list_objects(  # noqa: PLR0913
         )
         for obj in objects:
             yield str(obj) + "\n"
+
+    def list_objects_generator(
+        hcp_h: HCPHandler,
+        path: str,
+        output_mode: HCPHandler.ListObjectsOutputMode,
+        files_only: bool,
+    ) -> Generator[dict[str, Any], Any, None]:
+        objects = hcp_h.list_objects(
+            path,
+            output_mode=output_mode,
+            files_only=files_only,
+        )
+        for obj in objects:
+            if obj.get("Size", 0):
+                obj["Size"] = str(
+                    Byte(obj.get("Size", 0)).best_prefix(system=SI)
+                )
+            yield obj
 
     hcp_h: HCPHandler = create_HCPHandler(context)
     hcp_h.mount_bucket(bucket)
@@ -419,19 +438,20 @@ def list_objects(  # noqa: PLR0913
 
     if pagination:
         click.echo_via_pager(
-            list_objects_generator(
+            list_objects_pagination_generator(
                 hcp_h,
                 path_with_slash,
-                files_only,
                 output_mode,
+                files_only,
             ),
         )
     else:
         lt.stream(
-            hcp_h.list_objects(
+            list_objects_generator(
+                hcp_h,
                 path_with_slash,
-                output_mode=output_mode,
-                files_only=files_only,
+                output_mode,
+                files_only,
             ),
             headers="keys",
         )


### PR DESCRIPTION
## Summary
Solves #162 

This pull request refactors the object listing logic in the `NGPIris/cli/__init__.py` CLI, improving how object sizes are displayed and clarifying generator usage for paginated and non-paginated output. The main changes include introducing human-readable size formatting and reorganizing the generator functions for clarity.

**Enhancements to object listing and output formatting:**

* Added import of `bitmath`'s `SI` and `Byte` classes to enable human-readable size formatting for listed objects.
* Introduced a new `list_objects_generator` function that yields dictionaries with formatted "Size" fields (e.g., "1.2 MB" instead of raw bytes) for non-paginated output.
* Updated the non-paginated listing to use the new `list_objects_generator`, ensuring all outputted objects have human-readable sizes.

**Code organization and clarity:**

* Renamed the original generator to `list_objects_pagination_generator` for paginated output to clarify its distinct purpose and maintain separation of concerns. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL384-R389) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL422-R454)
* Adjusted the order and parameters of function calls to match the new generator signatures, improving code readability and maintainability.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
