### PR TITLE
Fix list objects graphical bug

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -345,6 +345,12 @@ def download(  # noqa: PLR0913
 @click.argument("bucket")
 @click.argument("path", required=False)
 @click.option(
+    "-bs",
+    "--batch_size",
+    help="Number of rows added to the output at a time. Default value is 25",
+    default=25,
+)
+@click.option(
     "-p",
     "--pagination",
     help="Output as a paginator",
@@ -370,6 +376,7 @@ def list_objects(  # noqa: PLR0913
     context: Context,
     bucket: str,
     path: str,
+    batch_size: int,
     pagination: bool,
     files_only: bool,
     extended_information: bool,
@@ -420,8 +427,8 @@ def list_objects(  # noqa: PLR0913
             yield obj
 
     def _render_objects_table(
-        table_data: Generator[dict[str, Any], Any, None], batch_size: int = 25
-    ):
+        table_data: Generator[dict[str, Any], Any, None], batch_size: int
+    ) -> None:
         rows = []
         for row in table_data:
             rows.append(row)
@@ -471,6 +478,7 @@ def list_objects(  # noqa: PLR0913
                 output_mode,
                 files_only,
             ),
+            batch_size,
         )
 
 

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -17,6 +17,7 @@ from NGPIris.cli.helpers import (
     download_folder,
     ensure_destination_dir,
     object_is_folder,
+    render_objects_table,
 )
 from NGPIris.cli.sections import SectionedGroup
 from NGPIris.hcp.exceptions import IsFolderObjectError, ObjectDoesNotExistError
@@ -244,12 +245,12 @@ def delete(
                     + '", the following file objects would have been deleted '
                     + "(this list excludes any potential sub-folders):",
                 )
-                lt.stream(
+                render_objects_table(
                     hcp_h.list_objects(
                         hcp_object,
                         files_only=True,
                     ),
-                    headers="keys",
+                    -1,
                 )
 
 
@@ -427,25 +428,6 @@ def list_objects(  # noqa: PLR0913
                 )
             yield obj
 
-    def _render_objects_table(
-        table_data: Generator[dict[str, Any], Any, None], batch_size: int
-    ) -> None:
-        rows = []
-        positive_batch_size = batch_size > 0
-        for row in table_data:
-            rows.append(row)
-            if positive_batch_size and (
-                not len(rows) % batch_size
-            ):  # Check if `len(rows)` is a mutliple of `batch_size`
-                click.echo(tabulate(rows, headers="keys"))
-                click.echo(
-                    "(Press any key to get more rows or ctrl+c to abort...)",
-                    nl=False,
-                )
-                click.getchar()
-                click.clear()
-        click.echo(tabulate(rows, headers="keys"))
-
     hcp_h: HCPHandler = create_HCPHandler(context)
     hcp_h.mount_bucket(bucket)
     output_mode = (
@@ -473,7 +455,7 @@ def list_objects(  # noqa: PLR0913
             ),
         )
     else:
-        _render_objects_table(
+        render_objects_table(
             list_objects_generator(
                 hcp_h,
                 path_with_slash,
@@ -736,9 +718,9 @@ def simple_search(
         case_sensitive=case_sensitive,
     )
     click.echo("Search results:")
-    lt.stream(
+    render_objects_table(
         list_of_results,
-        headers="keys",
+        -1,
     )
 
 
@@ -791,9 +773,9 @@ def fuzzy_search(
         threshold=threshold,
     )
     click.echo("Search results:")
-    lt.stream(
+    render_objects_table(
         list_of_results,
-        headers="keys",
+        -1,
     )
 
 

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any
 
 import click
-import lazy_table as lt
 from bitmath import SI, Byte
 from click.core import Context
 from tabulate import tabulate
@@ -347,7 +346,9 @@ def download(  # noqa: PLR0913
 @click.option(
     "-bs",
     "--batch_size",
-    help="Number of rows added to the output at a time. Default value is 25",
+    help="Number of rows added to the output at a time. If value is zero or a "
+    "negative number, all rows will be displayed in one go. "
+    "Default value is 25",
     default=25,
 )
 @click.option(
@@ -430,9 +431,10 @@ def list_objects(  # noqa: PLR0913
         table_data: Generator[dict[str, Any], Any, None], batch_size: int
     ) -> None:
         rows = []
+        positive_batch_size = batch_size > 0
         for row in table_data:
             rows.append(row)
-            if (
+            if positive_batch_size and (
                 not len(rows) % batch_size
             ):  # Check if `len(rows)` is a mutliple of `batch_size`
                 click.echo(tabulate(rows, headers="keys"))

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -420,14 +420,14 @@ def list_objects(  # noqa: PLR0913
             yield obj
 
     def _render_objects_table(
-        table_data: Generator[dict[str, Any], Any, None], batch_size: int = 10
+        table_data: Generator[dict[str, Any], Any, None], batch_size: int = 25
     ):
         rows = []
         for row in table_data:
             rows.append(row)
             if (
                 not len(rows) % batch_size
-            ):  # Check if len(rows) is a mutliple of batch_size
+            ):  # Check if `len(rows)` is a mutliple of `batch_size`
                 click.echo(tabulate(rows, headers="keys"))
                 click.echo(
                     "(Press any key to get more rows or ctrl+c to abort...)",

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -419,6 +419,24 @@ def list_objects(  # noqa: PLR0913
                 )
             yield obj
 
+    def _render_objects_table(
+        table_data: Generator[dict[str, Any], Any, None], batch_size: int = 10
+    ):
+        rows = []
+        for row in table_data:
+            rows.append(row)
+            if (
+                not len(rows) % batch_size
+            ):  # Check if len(rows) is a mutliple of batch_size
+                click.echo(tabulate(rows, headers="keys"))
+                click.echo(
+                    "(Press any key to get more rows or ctrl+c to abort...)",
+                    nl=False,
+                )
+                click.getchar()
+                click.clear()
+        click.echo(tabulate(rows, headers="keys"))
+
     hcp_h: HCPHandler = create_HCPHandler(context)
     hcp_h.mount_bucket(bucket)
     output_mode = (
@@ -446,14 +464,13 @@ def list_objects(  # noqa: PLR0913
             ),
         )
     else:
-        lt.stream(
+        _render_objects_table(
             list_objects_generator(
                 hcp_h,
                 path_with_slash,
                 output_mode,
                 files_only,
             ),
-            headers="keys",
         )
 
 

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -1,11 +1,13 @@
 import os
 import sys
 from pathlib import Path
+from typing import Any, Generator
 
 import click
 from bitmath import Byte, TiB
 from boto3 import set_stream_logger
 from click.core import Context
+from tabulate import tabulate
 
 from NGPIris import HCPHandler
 
@@ -161,3 +163,27 @@ def download_file(
             " use the -f / --force option"
         )
     hcp_h.download_file(source, downloaded_source.as_posix())
+
+
+def render_objects_table(
+    table_data: Generator[dict[str, Any], Any, None], batch_size: int
+) -> None:
+    """
+    Helper function for lazily displaying objects in a table with a given batch
+    size.
+    """
+    rows = []
+    positive_batch_size = batch_size > 0
+    for row in table_data:
+        rows.append(row)
+        if positive_batch_size and (
+            not len(rows) % batch_size
+        ):  # Check if `len(rows)` is a mutliple of `batch_size`
+            click.echo(tabulate(rows, headers="keys"))
+            click.echo(
+                "(Press any key to get more rows or ctrl+c to abort...)",
+                nl=False,
+            )
+            click.getchar()
+            click.clear()
+    click.echo(tabulate(rows, headers="keys"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "tqdm >= 4.66.2",
     "click >= 8.1.7",
     "bitmath == 1.3.3.1",
-    "lazy_table == 0.2.1",
     "more-itertools == 10.7.0",
     "ruff>=0.14.5",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -259,18 +259,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lazy-table"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tabulate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/c8/444ab09de64d906cca5895caf1b553f4f0e48ed01d3175276153df81e923/lazy-table-0.2.1.tar.gz", hash = "sha256:cc724a895ad55f3b65129a95f4bab58b5787a03d282470c4ddb02ff33386d433", size = 4560, upload-time = "2022-02-02T15:26:04.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/5d/b71cd562429fd16d698610bebe7e4e8d88ed8222d2e084bcb051e6c6b701/lazy_table-0.2.1-py3-none-any.whl", hash = "sha256:342f19a49befc7fc31c393f6bd665938b75e0f73cef1560c7f228c860fc76a14", size = 5467, upload-time = "2022-02-02T15:26:03.056Z" },
-]
-
-[[package]]
 name = "libcst"
 version = "1.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -453,13 +441,12 @@ wheels = [
 
 [[package]]
 name = "ngpiris"
-version = "5.6.2"
+version = "5.6.3.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "bitmath" },
     { name = "boto3" },
     { name = "click" },
-    { name = "lazy-table" },
     { name = "more-itertools" },
     { name = "parse" },
     { name = "rapidfuzz" },
@@ -483,7 +470,6 @@ requires-dist = [
     { name = "bitmath", specifier = "==1.3.3.1" },
     { name = "boto3", specifier = "==1.35.81" },
     { name = "click", specifier = ">=8.1.7" },
-    { name = "lazy-table", specifier = "==0.2.1" },
     { name = "more-itertools", specifier = "==10.7.0" },
     { name = "parse", specifier = ">=1.19.1" },
     { name = "rapidfuzz", specifier = ">=3.10.1" },


### PR DESCRIPTION
## Contents
Resolves the issue of lazy tables not rendering properly

### Summary
This pull request introduces enhancements to the `list_objects` CLI command, focusing on improving the user experience when displaying large sets of objects. The most notable change is the addition of a batch output mode, allowing users to view objects in configurable chunks, with human-readable file sizes. Additionally, some minor naming and import adjustments are included.

**Improvements to object listing and output:**

* Added a `--batch_size` option to the `list_objects` command, letting users specify how many rows to display at a time (default: 25). Output is now rendered in batches, with a prompt to continue after each batch. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR347-R352) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR379) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR411-R446) [[4]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL422-R481)
* File sizes in the object listing are now displayed in a human-readable format using the `bitmath` library. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR9) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR411-R446)

**Refactoring and minor fixes:**

* Refactored the internal generator functions for listing objects, introducing more descriptive names and separating pagination from batch rendering logic. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL384-R396) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aR411-R446) [[3]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL422-R481)
* Changed the `mode` match case in the `delete` command from `"files"` to `"file"` for consistency. [[1]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL207-R208) [[2]](diffhunk://#diff-3df7adc2bef8046e11e4db2bf55a0d87076285165108591c6e0d29da41575c3aL234-R235)


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
