### PR TITLE
5.6.6

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -380,7 +380,7 @@ def download(  # noqa: PLR0913
 def list_objects(  # noqa: PLR0913
     context: Context,
     bucket: str,
-    path: str,
+    path: str | None,
     batch_size: int,
     pagination: bool,
     files_only: bool,
@@ -439,7 +439,7 @@ def list_objects(  # noqa: PLR0913
         else HCPHandler.ListObjectsOutputMode.SIMPLE
     )
 
-    if not hcp_h._is_object_folder(path):
+    if path and not hcp_h._is_object_folder(path):
         msg = "The provided path is a file, which is not a valid path"
         raise IsFileObjectError(msg)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.6.4"
+version = "5.6.6"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "ngpiris"
-version = "5.6.4"
+version = "5.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "bitmath" },


### PR DESCRIPTION
## Contents
This pull request introduces a minor version bump and improves the robustness of the `list_objects` functionality by allowing for an optional `path` parameter and handling cases where `path` may be `None`.

Key changes:

Function signature and logic improvements:

* Updated the `list_objects` function in `NGPIris/cli/__init__.py` to accept an optional `path` parameter (`str | None`), enhancing flexibility when listing objects.
* Modified the `list_objects_generator` logic to check that `path` is not `None` before validating if it is an object folder, preventing errors when `path` is omitted.

Versioning:

* Bumped the package version to `5.6.6` in `pyproject.toml` to reflect the new changes.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions