### PR TITLE
Add hashing to cli

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -24,6 +24,7 @@ from NGPIris.hcp.exceptions import (
     IsFolderObjectError,
     ObjectDoesNotExistError,
 )
+from NGPIris.utils.utils import base64_hashing, md5_hashing
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -800,6 +801,27 @@ def test_connection(context: Context, bucket: str) -> None:
     """
     hcp_h: HCPHandler = create_HCPHandler(context)
     click.echo(hcp_h.test_connection(bucket))
+
+
+@cli.command(section="Utility commands")
+# @click.argument("username")
+# @click.argument("password")
+@click.pass_context
+def hash_credentials(context: Context) -> None:
+    username: str = click.prompt(
+        "Please enter your username (a.k.a aws_access_key_id)",
+    )
+    h_username = base64_hashing(username)
+
+    password: str = click.prompt(
+        "Please enter your password (a.k.a aws_secret_access_key)",
+        hide_input=True,
+        confirmation_prompt=True,
+    )
+    h_password = md5_hashing(password)
+
+    click.echo("Your hashed username is " + h_username)
+    click.echo("Your hashed password is " + h_password)
 
 
 # -------------------- Generate credentials command --------------------

--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -803,11 +803,17 @@ def test_connection(context: Context, bucket: str) -> None:
     click.echo(hcp_h.test_connection(bucket))
 
 
-@cli.command(section="Utility commands")
+@cli.command(
+    section="Utility commands",
+    short_help="Generate the hashes for a username and password.",
+)
 # @click.argument("username")
 # @click.argument("password")
 @click.pass_context
 def hash_credentials(context: Context) -> None:
+    """
+    Generate the hashes for a username and password.
+    """
     username: str = click.prompt(
         "Please enter your username (a.k.a aws_access_key_id)",
     )

--- a/NGPIris/cli/helpers.py
+++ b/NGPIris/cli/helpers.py
@@ -62,11 +62,11 @@ def create_HCPHandler(context: Context) -> HCPHandler:
         )
 
         aws_access_key_id: str = click.prompt(
-            "Please enter your base64 hashed aws_access_key_id",
+            "Please enter your base64 hashed username (a.k.a aws_access_key_id)",
         )
 
         aws_secret_access_key: str = click.prompt(
-            "Please enter your md5 hashed aws_secret_access_key",
+            "Please enter your md5 hashed password (a.k.a aws_secret_access_key)",
             hide_input=True,
             confirmation_prompt=True,
         )


### PR DESCRIPTION
## Summary
This pull request introduces a new CLI utility command for generating hashed credentials and improves the clarity of user prompts related to credential input. The main changes are grouped into two themes: new features and improvements to user experience.

New CLI feature:

* Added a `hash_credentials` command to the CLI, allowing users to generate hashed versions of their username and password using `base64_hashing` and `md5_hashing` functions. This command prompts for input and displays the hashed results.
* Imported `base64_hashing` and `md5_hashing` from `NGPIris.utils.utils` to support the new hashing functionality.

User experience improvements:

* Updated credential prompts in `create_HCPHandler` to clarify that the username corresponds to `aws_access_key_id` and the password to `aws_secret_access_key`, making instructions more user-friendly and consistent with the new `hash_credentials` command.