### PR TITLE
144 feature request expand information for list buckets

### DIFF
--- a/NGPIris/cli/__init__.py
+++ b/NGPIris/cli/__init__.py
@@ -664,7 +664,7 @@ def delete_bucket(
         HCPHandler.ListBucketsOutputMode,
         case_sensitive=False,
     ),
-    default=HCPHandler.ListBucketsOutputMode.SIMPLE,
+    default=HCPHandler.ListBucketsOutputMode.EXTENDED,
 )
 @click.pass_context
 def list_buckets(

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -2,7 +2,7 @@ import re
 from configparser import ConfigParser
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, OrderedDict
 
 from bitmath import SI, Byte, TiB
 from bitmath import parse_string as bitmath_parse
@@ -459,8 +459,8 @@ class HCPHandler:
                     bi_fields = [
                         "Hard quota",
                         "Soft quota (%)",
-                        "Description",
                         "Owner",
+                        "Description",
                     ]
                     output_list.append(
                         base
@@ -469,21 +469,37 @@ class HCPHandler:
                     )
 
                 case HCPHandler.ListBucketsOutputMode.SIMPLE:
-                    stats_fields = [
+                    final_field_order: list[str] = [
+                        "Bucket",
                         "Ingested volume",
                         "Storage capacity used",
+                        "Hard quota",
+                        "Soft quota (%)",
                         "Object count",
+                        "Owner",
+                        "Description",
+                    ]
+                    stats_fields = [
+                        "Object count",
+                        "Ingested volume",
+                        "Storage capacity used",
                     ]
                     bi_fields = [
                         "Hard quota",
                         "Soft quota (%)",
                         "Owner",
+                        "Description",
                     ]
-
-                    output_list.append(
+                    fields = (
                         base
                         | {f: stats[f] for f in stats_fields}
                         | {f: bucket_information[f] for f in bi_fields}
+                    )
+                    output_list.append(
+                        OrderedDict(
+                            (field, fields[field])
+                            for field in final_field_order
+                        )
                     )
 
                 case HCPHandler.ListBucketsOutputMode.MINIMAL:

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -438,20 +438,29 @@ class HCPHandler:
                 Byte(stats["Ingested volume"]).best_prefix(SI)
             )
 
-            stats["Storage capacity used"] = str(
-                Byte(stats["Storage capacity used"]).best_prefix(SI)
-            )
+            storage_capacity_used_bytes = Byte(
+                stats["Storage capacity used"]
+            ).best_prefix(SI)
+            stats["Storage capacity used"] = str(storage_capacity_used_bytes)
 
-            bucket_information["Hard quota"] = str(
-                bitmath_parse(bucket_information["Hard quota"]).best_prefix(SI)
-            )
+            hard_quota_bytes = bitmath_parse(
+                bucket_information["Hard quota"]
+            ).best_prefix(SI)
+            bucket_information["Hard quota"] = str(hard_quota_bytes)
 
             bucket_information["Soft quota (%)"] = bucket_information[
                 "Soft quota"
             ]
             del bucket_information["Soft quota"]
 
-            fields = base | stats | bucket_information
+            extra_info = {
+                "Storage capacity used (%)": round(
+                    storage_capacity_used_bytes / hard_quota_bytes, 3
+                )
+                * 100
+            }
+
+            fields = base | stats | bucket_information | extra_info
 
             match output_mode:
                 case HCPHandler.ListBucketsOutputMode.FULL:
@@ -460,11 +469,16 @@ class HCPHandler:
                 case HCPHandler.ListBucketsOutputMode.EXTENDED:
                     field_order = [
                         "Bucket",
+                        "Ingested volume",
+                        "Storage capacity used",
                         "Hard quota",
+                        "Storage capacity used (%)",
                         "Soft quota (%)",
+                        "Object count",
                         "Owner",
                         "Description",
                     ]
+
                     output_list.append(
                         OrderedDict(
                             (field, fields[field]) for field in field_order
@@ -474,11 +488,9 @@ class HCPHandler:
                 case HCPHandler.ListBucketsOutputMode.SIMPLE:
                     field_order = [
                         "Bucket",
-                        "Ingested volume",
                         "Storage capacity used",
                         "Hard quota",
-                        "Soft quota (%)",
-                        "Object count",
+                        "Storage capacity used (%)",
                         "Owner",
                         "Description",
                     ]

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -442,34 +442,37 @@ class HCPHandler:
                 Byte(stats["Storage capacity used"]).best_prefix(SI)
             )
 
-            bucket_information["Hard quota"] = bitmath_parse(
-                bucket_information["Hard quota"]
-            ).best_prefix(SI)
+            bucket_information["Hard quota"] = str(
+                bitmath_parse(bucket_information["Hard quota"]).best_prefix(SI)
+            )
 
             bucket_information["Soft quota (%)"] = bucket_information[
                 "Soft quota"
             ]
             del bucket_information["Soft quota"]
 
+            fields = base | stats | bucket_information
+
             match output_mode:
                 case HCPHandler.ListBucketsOutputMode.FULL:
-                    output_list.append(base | stats | bucket_information)
+                    output_list.append(fields)
 
                 case HCPHandler.ListBucketsOutputMode.EXTENDED:
-                    bi_fields = [
+                    field_order = [
+                        "Bucket",
                         "Hard quota",
                         "Soft quota (%)",
                         "Owner",
                         "Description",
                     ]
                     output_list.append(
-                        base
-                        | stats
-                        | {f: bucket_information[f] for f in bi_fields}
+                        OrderedDict(
+                            (field, fields[field]) for field in field_order
+                        )
                     )
 
                 case HCPHandler.ListBucketsOutputMode.SIMPLE:
-                    final_field_order: list[str] = [
+                    field_order = [
                         "Bucket",
                         "Ingested volume",
                         "Storage capacity used",
@@ -479,41 +482,24 @@ class HCPHandler:
                         "Owner",
                         "Description",
                     ]
-                    stats_fields = [
-                        "Object count",
-                        "Ingested volume",
-                        "Storage capacity used",
-                    ]
-                    bi_fields = [
-                        "Hard quota",
-                        "Soft quota (%)",
-                        "Owner",
-                        "Description",
-                    ]
-                    fields = (
-                        base
-                        | {f: stats[f] for f in stats_fields}
-                        | {f: bucket_information[f] for f in bi_fields}
-                    )
                     output_list.append(
                         OrderedDict(
-                            (field, fields[field])
-                            for field in final_field_order
+                            (field, fields[field]) for field in field_order
                         )
                     )
 
                 case HCPHandler.ListBucketsOutputMode.MINIMAL:
-                    stats_fields = ["Object count"]
-                    bi_fields = [
+                    field_order = [
+                        "Bucket",
                         "Hard quota",
                         "Soft quota (%)",
+                        "Object count",
                         "Owner",
                     ]
-
                     output_list.append(
-                        base
-                        | {f: stats[f] for f in stats_fields}
-                        | {f: bucket_information[f] for f in bi_fields}
+                        OrderedDict(
+                            (field, fields[field]) for field in field_order
+                        )
                     )
 
                 case HCPHandler.ListBucketsOutputMode.BUCKET_ONLY:

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -4,7 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from bitmath import Byte, TiB
+from bitmath import SI, Byte, TiB
 from bitmath import parse_string as bitmath_parse
 from boto3 import client
 from boto3.s3.transfer import TransferConfig
@@ -434,26 +434,22 @@ class HCPHandler:
                 for k, _ in bucket_information.items()
             }
 
-            # Parse `"Hard quota"` value to be just a number
-            bucket_information["Hard quota (Bytes)"] = int(
-                bitmath_parse(
-                    # TODO(EB): `"Hard quota"` is written as being decimal
-                    # (MB, GB, TB, etc), but it is probably binary
-                    # (MiB, GiB, TiB, etc). As such the `bitmath_parse` will not
-                    # be 100% correct, and should be corrected soon, but that is
-                    # annoying so I won't right now :/
-                    bucket_information["Hard quota"]
-                ).to_Byte()
+            stats["Ingested volume"] = str(
+                Byte(stats["Ingested volume"]).best_prefix(SI)
             )
+
+            stats["Storage capacity used"] = str(
+                Byte(stats["Storage capacity used"]).best_prefix(SI)
+            )
+
+            bucket_information["Hard quota"] = bitmath_parse(
+                bucket_information["Hard quota"]
+            ).best_prefix(SI)
 
             bucket_information["Soft quota (%)"] = bucket_information[
                 "Soft quota"
             ]
             del bucket_information["Soft quota"]
-
-            for col in ["Ingested volume", "Storage capacity used"]:
-                stats[col + " (Bytes)"] = stats[col]
-                del stats[col]
 
             match output_mode:
                 case HCPHandler.ListBucketsOutputMode.FULL:
@@ -461,7 +457,7 @@ class HCPHandler:
 
                 case HCPHandler.ListBucketsOutputMode.EXTENDED:
                     bi_fields = [
-                        "Hard quota (Bytes)",
+                        "Hard quota",
                         "Soft quota (%)",
                         "Description",
                         "Owner",
@@ -474,12 +470,12 @@ class HCPHandler:
 
                 case HCPHandler.ListBucketsOutputMode.SIMPLE:
                     stats_fields = [
-                        "Ingested volume (Bytes)",
-                        "Storage capacity used (Bytes)",
+                        "Ingested volume",
+                        "Storage capacity used",
                         "Object count",
                     ]
                     bi_fields = [
-                        "Hard quota (Bytes)",
+                        "Hard quota",
                         "Soft quota (%)",
                         "Owner",
                     ]
@@ -493,7 +489,7 @@ class HCPHandler:
                 case HCPHandler.ListBucketsOutputMode.MINIMAL:
                     stats_fields = ["Object count"]
                     bi_fields = [
-                        "Hard quota (Bytes)",
+                        "Hard quota",
                         "Soft quota (%)",
                         "Owner",
                     ]

--- a/NGPIris/hcp/hcp.py
+++ b/NGPIris/hcp/hcp.py
@@ -503,10 +503,8 @@ class HCPHandler:
                 case HCPHandler.ListBucketsOutputMode.MINIMAL:
                     field_order = [
                         "Bucket",
-                        "Hard quota",
-                        "Soft quota (%)",
+                        "Storage capacity used (%)",
                         "Object count",
-                        "Owner",
                     ]
                     output_list.append(
                         OrderedDict(


### PR DESCRIPTION
## Summary
This pull request updates the bucket listing functionality to provide more user-friendly output and improves the handling and display of storage-related statistics. The most important changes are grouped below:

**User Experience Improvements:**

* The default output mode for the `list_buckets` command has been changed from `SIMPLE` to `EXTENDED`, providing more detailed information by default.
* Output fields for each mode (`FULL`, `EXTENDED`, `SIMPLE`, `MINIMAL`) are now consistently ordered and returned as `OrderedDict`s, making the output more predictable and readable.

**Data Presentation and Calculation Enhancements:**

* Storage-related values such as "Ingested volume", "Storage capacity used", and "Hard quota" are now converted to human-readable units using SI prefixes, rather than showing only raw byte counts.
* A new field, "Storage capacity used (%)", has been added, showing the percentage of used storage relative to the hard quota, rounded to three decimal places.

**Code Maintenance:**

* The import section in `hcp.py` was updated to include `SI` from `bitmath` and to import `OrderedDict` for improved output formatting.