### PR TITLE
Add deprecation warning for `request_token`

### DIFF
--- a/NGPIris/hci/hci.py
+++ b/NGPIris/hci/hci.py
@@ -1,5 +1,6 @@
 from json import load
 from pathlib import Path
+from warnings import deprecated
 
 from requests import Response, post
 from urllib3 import disable_warnings
@@ -53,18 +54,32 @@ class HCIHandler:
             self.auth_port = credentials["auth_port"]
             self.api_port = credentials["api_port"]
 
-        self.token = ""
-
         self.use_ssl = use_ssl
 
         if not self.use_ssl:
             disable_warnings()
 
+        self.token = self._request_token()
+
+    @deprecated(
+        "`request_token` is depricated in favour of integrating its "
+        "functionality in the `HCIHandler` constructor"
+    )
     def request_token(self) -> None:
         """
         Request a token from the HCI, which is stored in the HCIHandler object.
         The token is used for every operation that needs to send a request to
         HCI.
+
+        :raises ConnectionError:
+            If there was a problem when requesting a token
+        """
+        self.token = self._request_token()
+
+    def _request_token(self) -> str:
+        """
+        Request a token from the HCI. The token is used for every operation
+        that needs to send a request to HCI.
 
         :raises ConnectionError:
             If there was a problem when requesting a token
@@ -92,7 +107,7 @@ class HCIHandler:
             raise ConnectionError(error_msg) from None
 
         token: str = response.json()["access_token"]
-        self.token = token
+        return token
 
     def list_index_names(self) -> list[str]:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "ngpiris"
-version = "5.6.6"
+version = "5.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "bitmath" },


### PR DESCRIPTION
## Summary
This pull request refactors the token handling logic in the `HCIHandler` class to improve clarity and encourage best practices. The main change is moving token retrieval to the constructor and deprecating the old `request_token` method. This ensures that a valid token is always available upon initialization and reduces the risk of using the handler without authentication.

**Token management improvements:**

* The token is now automatically requested and set during initialization in the `HCIHandler` constructor, eliminating the need for manual token retrieval after instantiation.
* The old `request_token` method is marked as deprecated, guiding developers to use the new pattern where token acquisition is handled internally.
* Token retrieval logic is moved to a new private method `_request_token`, which is called by the constructor and the (now deprecated) `request_token` method. This improves code organization and reuse. [[1]](diffhunk://#diff-e334bf43bdbd743eb0493697c9bb82f235cd974a0a5970a481d68444d5cb4d7cL56-R83) [[2]](diffhunk://#diff-e334bf43bdbd743eb0493697c9bb82f235cd974a0a5970a481d68444d5cb4d7cL95-R110)

**Code hygiene:**

* Added an import for `deprecated` from `warnings` to support the deprecation decorator.