### PR TITLE
5.6.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "5.6.7"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",
-    "urllib3 == 2.6.3",
+    "urllib3==2.7.0",
     "boto3 == 1.35.81",
     "parse >= 1.19.1",
     "RapidFuzz >= 3.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NGPIris"
-version = "5.6.7"
+version = "5.6.8"
 readme = "README.md"
 dependencies = [
     "requests >= 2.31.0",

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,6 @@ dependencies = [
     { name = "click" },
     { name = "more-itertools" },
     { name = "parse" },
-    { name = "pylint" },
     { name = "rapidfuzz" },
     { name = "requests" },
     { name = "ruff" },
@@ -231,6 +230,7 @@ dependencies = [
 dev = [
     { name = "basedpyright" },
     { name = "icecream" },
+    { name = "pylint" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -242,7 +242,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "more-itertools", specifier = "==10.7.0" },
     { name = "parse", specifier = ">=1.19.1" },
-    { name = "pylint", specifier = ">=4.0.5" },
     { name = "rapidfuzz", specifier = ">=3.10.1" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.14.5" },
@@ -255,6 +254,7 @@ requires-dist = [
 dev = [
     { name = "basedpyright", specifier = ">=1.33.0" },
     { name = "icecream" },
+    { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.14.5" },
 ]
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.1"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -349,9 +349,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -156,11 +156,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -218,7 +218,6 @@ dependencies = [
     { name = "click" },
     { name = "more-itertools" },
     { name = "parse" },
-    { name = "pylint" },
     { name = "rapidfuzz" },
     { name = "requests" },
     { name = "ruff" },
@@ -231,6 +230,7 @@ dependencies = [
 dev = [
     { name = "basedpyright" },
     { name = "icecream" },
+    { name = "pylint" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -242,7 +242,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "more-itertools", specifier = "==10.7.0" },
     { name = "parse", specifier = ">=1.19.1" },
-    { name = "pylint", specifier = ">=4.0.5" },
     { name = "rapidfuzz", specifier = ">=3.10.1" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.14.5" },
@@ -255,6 +254,7 @@ requires-dist = [
 dev = [
     { name = "basedpyright", specifier = ">=1.33.0" },
     { name = "icecream" },
+    { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.14.5" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,6 @@ dependencies = [
     { name = "click" },
     { name = "more-itertools" },
     { name = "parse" },
-    { name = "pylint" },
     { name = "rapidfuzz" },
     { name = "requests" },
     { name = "ruff" },
@@ -231,6 +230,7 @@ dependencies = [
 dev = [
     { name = "basedpyright" },
     { name = "icecream" },
+    { name = "pylint" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -242,19 +242,19 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "more-itertools", specifier = "==10.7.0" },
     { name = "parse", specifier = ">=1.19.1" },
-    { name = "pylint", specifier = ">=4.0.5" },
     { name = "rapidfuzz", specifier = ">=3.10.1" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", specifier = ">=0.14.5" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tqdm", specifier = ">=4.66.2" },
-    { name = "urllib3", specifier = "==2.6.3" },
+    { name = "urllib3", specifier = "==2.7.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.33.0" },
     { name = "icecream" },
+    { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.14.5" },
 ]
@@ -490,9 +490,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
## Contents
### Summary
This pull request updates the `pyproject.toml` file to bump the project version and upgrade a dependency.

Dependency and version updates:

* Updated the project version from `5.6.7` to `5.6.8` to reflect new changes.
* Upgraded the `urllib3` dependency from version `2.6.3` to `2.7.0` for improved compatibility and security.


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation
```
pip install NGPIris
```

### Tests
Tests can as of right now, only be performed using `pytest` on a local instance of Iris. CI/CD for this is currently not possible.

### Expected outcome:
PyTest resolves without crashes

## Confirmations:
- [x] Code tested by @erik-brink 
